### PR TITLE
introduce install-vmod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,33 @@ jobs:
       - run: |
           cd bob
           bob_testdir/test.sh
+  install-vmod:
+    docker:
+      - image: debian:buster
+    steps:
+      - checkout
+      - run: |
+          apt-get update
+          apt-get -qy install curl
+          curl -s https://packagecloud.io/install/repositories/varnishcache/varnish71/script.deb.sh | bash
+          apt-get install -qy automake build-essential libtool-bin python3-docutils varnish varnish-dev
+          cd install-vmod
+
+          VMOD_DYNAMIC_VERSION=2.6.0
+          VMOD_DYNAMIC_COMMIT=9666973952f62110c872d720af3dae0b85b4b597
+          VMOD_DYNAMIC_SHA512SUM=e62f1ee801ab2c9e22f5554bbe40c239257e2c46ea3d2ae19b465b1c82edad6f675417be8f7351d4f9eddafc9ad6c0149f88edc44dd0b922ad82e5d75b6b15a5
+          ./install-vmod https://github.com/nigoroll/libvmod-dynamic/archive/$VMOD_DYNAMIC_COMMIT.tar.gz $VMOD_DYNAMIC_SHA512SUM
+
+          VARNISH_MODULES_COMMIT=0329e2549c31129b35ce163f024f298b10d6551a
+          VARNISH_MODULES_SHA512SUM=526a19a51143174d63ca27f43fa4da713e00301ae89335bb794c34971729a630ad7ee33b4fea374059ea141bfc432b5f93632d83da06a179c8046da9dbb9f525
+          ./install-vmod https://github.com/varnish/varnish-modules/archive/$VARNISH_MODULES_COMMIT.tar.gz $VARNISH_MODULES_SHA512SUM
+
+          echo -e 'vcl 4.1; import var; import dynamic; backend be none;' > /tmp/test.vcl
+          varnishd -C -f /tmp/test.vcl
 
 workflows:
   build:
     jobs:
       - bob
       - build
+      - install-vmod

--- a/install-vmod/README.md
+++ b/install-vmod/README.md
@@ -1,0 +1,35 @@
+# What it is
+
+A script to download and install vmods. It's mainly aimed at containers since
+for other systems, packages are probably more appropriate.
+
+It should be able to build any distribution or source tarball for vmods using autotools, if you find one that doesn't work, please open an [issue](https://github.com/varnish/toolbox/issues/new).
+
+# How it is built
+
+It's a `shell` script so it doesn't need to be built, but you'll probably
+want to install it somewhere in your `PATH`
+
+# How it works
+
+Make sure you have the following installed:
+- varnish development files
+- curl
+- pkg-config
+- nproc
+- make
+- gcc/clang
+- automake
+- libtoolize
+- whatever dependencies the vmod needs
+
+From there, you can run
+
+``` bash
+install-vmod TARBALL_URL SHA512SUM
+```
+
+`TARBALL_URL` is the url to the tarball for the vmod you want to compile.
+The tarball is assumed to only have one directory in it.
+
+`SHA512SUM` is an optional `sha512` checksum to validate the tarball against.

--- a/install-vmod/install-vmod
+++ b/install-vmod/install-vmod
@@ -1,0 +1,98 @@
+#/bin/sh
+
+set -e
+
+usage() {
+	cat << EOF
+usage:
+    install_vmod URL [SHA512SUM]
+deps:
+- varnish development files
+- curl
+- pkg-config
+- nproc
+- make
+- gcc
+- automake
+- libtoolize
+- whatever dependencies the vmod needs
+EOF
+	exit $1
+}
+
+maybe_help() {
+	if [ "$1" == "-h" -o "$1" = "-help" -o "$1" = "--help" ]; then
+		usage
+		exit
+	fi
+}
+
+check_bin() {
+	if ! command "$@" >/dev/null 2>&1; then
+		echo "please install $1"
+		exit 1
+	fi
+}
+
+check_bin automake --version
+check_bin curl --version
+check_bin gcc --version
+check_bin libtool --version
+check_bin make --version
+check_bin nproc
+check_bin pkg-config --version
+check_bin rst2man --version
+check_bin tar --version
+
+if ! pkg-config varnishapi; then
+	echo "pkg-config couldn't find varnishapi (did you install the varnish dev file/package?)"
+	exit 1
+fi
+
+if [ $# != 1 -a $# != 2 ]; then
+	usage 1
+fi
+
+maybe_help "$1"
+maybe_help "$2"
+
+if [ -n "$1" ]; then
+	URL="$1"
+else
+	echo no TARBALL specified
+	exit 1
+fi
+
+SHA512SUM="$2"
+
+set -x
+
+rm -rf /tmp/module_to_build
+mkdir /tmp/module_to_build
+
+if [ -e "$URL" ]; then
+	cp "$URL" /tmp/module_to_build/src.tar.gz
+else
+	curl -fLo /tmp/module_to_build/src.tar.gz "$URL"
+fi
+
+cd /tmp/module_to_build
+
+if [ -n "$SHA512SUM" ]; then
+	echo "$SHA512SUM  src.tar.gz" | sha512sum -c -
+fi
+tar xavf src.tar.gz --strip 1
+
+if [ ! -x configure ]; then
+	if [ -e autogen.sh ]; then
+		./autogen.sh
+	elif [ -e bootstrap ]; then
+		./bootstrap
+	fi
+fi
+
+./configure
+make -j"$(nproc)" VERBOSE=1 check
+make -j"$(nproc)" VERBOSE=1 install
+
+rm -rf /tmp/module_to_build 


### PR DESCRIPTION
here's a dumb helper script to download, compile and install vmods (clever name, eh?). The goal is to use it when generating the official [varnish images](https://github.com/varnish/docker-varnish) and to include it so people can easily add their own vmods, but it could be used by @xcir's [vmod packager](https://github.com/xcir/vmod-packager) too, for example, so I'd rather have it in a central location.

tagging @Dridi for the shell review, and @ThijsFeryn since that's community-related