### PR TITLE
Pull secret required

### DIFF
--- a/s3-shield/helm/values.yaml
+++ b/s3-shield/helm/values.yaml
@@ -1,3 +1,7 @@
+---
+global:
+  imagePullSecrets:
+    - name: varnish-pull-secret
 server:
   extraEnvs:
     AWS_SHARED_CREDENTIALS_FILE: /etc/varnish/aws/s3.conf


### PR DESCRIPTION
Running the Helm chart without the pull secret results in the following error:

```
Failed to pull image "quay.io/varnish-software/varnish-plus:6.0.13r4": Error response from daemon: unauthorized: access to the requested resource is not authorized
```

https://docs.varnish-software.com/varnish-helm/guides/setting-up-repository/#creating-an-image-pull-secret describes the need for such a pull secret and also explains how to create it.

Also see https://github.com/varnish/docs/pull/1411 for a pull request that adds the keyword `docker-registry` to create valid secrets using credentials on the command line.