### PR TITLE
Add an AWS name tag

### DIFF
--- a/s3-shield/terraform-aws/instance_ve6.tf
+++ b/s3-shield/terraform-aws/instance_ve6.tf
@@ -23,5 +23,6 @@ resource "aws_instance" "tf-ve6" {
   user_data              = "${file("../cloud-init/cloud-init-s3-shield.yaml")}"
   tags = {
     Project = "varnish-s3-shield"
+    Name = "varnish-s3-shield"
   }
 }


### PR DESCRIPTION
Adding a `Name` tag to an EC2 instance makes it look more elegant in the AWS Console UI.