### PR TITLE
update secret mounting

### DIFF
--- a/s3-shield/helm/values.yaml
+++ b/s3-shield/helm/values.yaml
@@ -20,7 +20,6 @@ server:
   extraVolumeMounts:
     - name: varnish-s3-conf
       mountPath: /etc/varnish/aws/
-      subpath: /etc/varnish/s3.conf
     - name: varnish-s3-vcl
       mountPath: /etc/varnish/default.vcl
       subPath: default.vcl


### PR DESCRIPTION
pod appears healthy but without mounted secret because of invalid spec.
