### PR TITLE
Add example on how to push content to varnish without an origin

### DIFF
--- a/docker-compose-examples/pushmode/README.md
+++ b/docker-compose-examples/pushmode/README.md
@@ -1,0 +1,30 @@
+# Clustered push-based objectstore
+
+This is an example with live video pushed to the objectstore
+
+# How to test:
+
+Push and fetch files:
+
+1. `docker compose up`
+   * starts 3 varnishes, and a loadbalancing varnish (just for reaching the varnishes)
+2. `curl http://localhost:6081/hello`
+   * get 404
+3. `curl -X POST --data-ascii "hello world" -H 'Content-Type: text/plain' -H 'Authorization: secret' -v http://localhost:6081/hello`
+   * get a good status
+4. `curl -v http://localhost:6081/hello`
+   * get "Hello world" and the Content-Type header you pushed
+
+Live video:
+
+1. `docker compose up`
+
+2. open http://localhost:6081/master.m3u8 in your favorite video player
+   * look at compose.yaml to see how ffmpeg is pushing live video to varnish
+
+
+# Things you probably want to change
+
+* Invalidation not implemented. Purge should "just work", VOD purging will be easier with ykey.
+* Host header is set to localhost, this is not ideal..
+* TTL is set statically in VCL

--- a/docker-compose-examples/pushmode/compose.yaml
+++ b/docker-compose-examples/pushmode/compose.yaml
@@ -1,0 +1,66 @@
+services:
+  lb:
+    depends_on:
+      - push-origin
+    image: 'quay.io/varnish-software/varnish-plus:latest'
+    volumes:
+      - ./load-balancer.vcl:/etc/varnish/default.vcl
+    ports:
+      - "6081:6081"
+
+  push-origin: &varnish
+    image: 'quay.io/varnish-software/varnish-plus:latest'
+    deploy:
+      replicas: 3
+    volumes:
+      - ./push.vcl:/etc/varnish/default.vcl
+
+  broadcaster:
+    image: 'quay.io/varnish-software/varnish-broadcaster:latest'
+    restart: always
+    environment:
+      VARNISH_BROADCASTER_CFG: /tmp/nodes/nodes.conf
+      VARNISH_BROADCASTER_EXTRA: -confwatch 1s
+    volumes:
+      - node_dir:/tmp/nodes
+    depends_on:
+      - discovery
+
+  discovery:
+    image: 'quay.io/varnish-software/varnish-discovery:latest'
+    environment:
+      VARNISH_DISCOVERY_FLAGS: dns --group push-origin --nodefile /tmp/nodes/nodes.conf --port 6081
+    volumes:
+      - node_dir:/tmp/nodes
+
+  live_video_generator:
+    image: 'linuxserver/ffmpeg:latest'
+    depends_on:
+      - lb
+    command: >
+      -threads 4
+      -f lavfi -i testsrc=s=1920x1080
+      -vf "drawtext=fontfile=monofonto.ttf: fontsize=84: box=1: boxcolor=black: fontcolor=white: x=790: y=890: text='%{gmtime\\:%H\\\\\\:%M\\\\\\:%S}',
+      drawtext=fontfile=monofonto.ttf: fontsize=84: box=1: boxcolor=black: fontcolor=white: x=600: y=45: text=Varnish Test Video"
+      -r 50
+      -sc_threshold 0
+      -vcodec libx264 -preset superfast
+      -f hls
+      -hls_time 2
+      -hls_flags delete_segments
+      -g 100
+      -keyint_min 100
+      -force_key_frames "expr:gte(t,n_forced*2)"
+      -loglevel 31
+      -stats
+      -method POST
+      -http_user_agent secret
+      http://lb:6081/master.m3u8
+
+
+volumes:
+  node_dir:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs

--- a/docker-compose-examples/pushmode/load-balancer.vcl
+++ b/docker-compose-examples/pushmode/load-balancer.vcl
@@ -1,0 +1,34 @@
+vcl 4.1;
+
+import activedns;
+import goto;
+import kvstore;
+import std;
+import udo;
+
+backend default none;
+
+sub vcl_init {
+    new origins_group = activedns.dns_group("push-origin:6081");
+    origins_group.set_ttl_rule(force);
+    origins_group.set_ttl(1s);
+
+    new origins = udo.director();
+    origins.subscribe(origins_group.get_tag());
+}
+
+
+sub vcl_recv {
+    set req.backend_hint = origins.backend();
+    return (pass);
+}
+
+sub vcl_backend_fetch {
+    if (bereq.http.force-origin) {
+    	set bereq.backend = goto.dns_backend(bereq.http.force-origin);
+    }
+}
+
+sub vcl_backend_response {
+    set beresp.http.origin = beresp.backend;
+}

--- a/docker-compose-examples/pushmode/push.vcl
+++ b/docker-compose-examples/pushmode/push.vcl
@@ -1,0 +1,131 @@
+vcl 4.1;
+
+import activedns;
+import kvstore;
+import std;
+import synthbackend;
+import udo;
+import utils;
+
+include "vha6/vha_auto.vcl";
+
+backend default none;
+
+sub vcl_init {
+    vha6_opts.set("broadcaster_host", "broadcaster");
+    vha6_opts.set("token", "secret123");
+    call vha6_token_init;
+}
+
+sub vcl_init {
+    new push_group = activedns.dns_group("push-origin:6081");
+    push_group.set_ttl_rule(force);
+    push_group.set_ttl(1s);
+
+    new push_cluster = udo.director();
+    push_cluster.subscribe(push_group.get_tag());
+
+    new push_opts = kvstore.init();
+    push_opts.set("token",  "abcde");
+}
+
+
+sub vcl_synth {
+    // This synth is just for delivering an empty response
+    if (resp.status == 1200) {
+        synthetic("");
+        set resp.body = {"
+{"status": true }
+"};
+        set resp.status = 200;
+        return(deliver);
+    }
+}
+sub vcl_recv {
+    set req.hash_ignore_busy = true; // FIXME: always?
+    // ffmpeg workaround:
+    if (req.http.user-agent == "secret") {
+        // set req.method = "POST";
+        set req.http.authorization = "secret";
+    }
+    set req.http.host = "localhost";
+    if (req.http.authorization == "secret") { // FIXME: pretend-authentication
+        if (req.method == "POST" || req.http.post-method == "true") {
+            set req.http.method = "GET";
+            set req.http.post-method = "true";
+            set req.hash_always_miss = true;
+            return (hash);
+        } else {
+            // Return a 404 if the cluster node reaches itself
+            if (push_cluster.self_identify(req.http.X-Cluster-Identifier)) {
+                return (synth(404));
+            }
+        }
+    }
+    // Block unhandled request methods. Invalidation logic goes above this block.
+    if (req.method != "GET" &&
+        req.method != "HEAD" &&
+        req.method != "POST") {
+        return(synth(405, "Method not allowed"));
+    }
+
+    unset req.http.authorization;
+}
+
+sub vcl_miss {
+    if (req.http.x-push-searching) {
+      return (synth(404));
+    }
+}
+
+sub vcl_backend_fetch {
+    // if the request was a POST, set the "mirror" backend 
+    // that will create a temporary backend 
+    // which will respond with the request body and headers to insert it into cache.
+    if (bereq.http.post-method == "true") {
+        std.log("Should insert object here");
+        set bereq.backend = synthbackend.mirror();
+        return(fetch);
+    }
+
+    // try to find the object within the cluster
+    if (push_cluster.self_is_next()) {
+        utils.resolve_backend(push_cluster.backend());
+        std.log("exhausted myself");
+    }
+    set bereq.backend = push_cluster.backend();
+    set bereq.http.x-push-searching = "true";
+    set bereq.http.X-Cluster-Identifier = push_cluster.get_identifier();
+    return (fetch);
+}
+
+sub vcl_backend_response {
+    if (bereq.http.post-method == "true") {
+        set beresp.ttl = 10m; // FIXME: This can be set with -t or -p default_ttl, but for more complex
+    } else if (bereq.http.x-push-searching && beresp.status != 200) {
+        return (retry);
+    }
+}
+
+sub vcl_deliver {
+    // If the request was a POST, then this response contains the original request
+    // We don't need the original data mirrored back at us, so instead we synth an empty response.
+    if (req.http.post-method == "true") {
+        return(synth(1200));
+    }
+    set resp.http.X-ttl = obj.ttl;
+}
+
+sub vcl_backend_error {
+    if (bereq.http.x-push-searching && std.healthy(push_cluster.backend())) {
+        return(retry);
+    }
+    // Give a 404 instead of a backend fetch failed since we don't have a backend.
+    set beresp.status = 404;
+    set beresp.http.Content-Type = "text/plain";
+    set beresp.http.Cache-Control = "no-store; no-cache";
+    set beresp.body   = """
+404 not found
+""";
+    return(deliver);
+}


### PR DESCRIPTION
This example has it's own readme.

The short summary, it lets you push objects to varnish and fetch them later, without a backend, so objects are stored in memory only (unless mse is configured)