### PR TITLE
Edge-tester: some minor tweaks

### DIFF
--- a/edge_tester/main.go
+++ b/edge_tester/main.go
@@ -215,16 +215,14 @@ func main() {
 		}
 	}
 
-	if all_good {
-		fmt.Println("all clear")
-		os.Exit(0)
+	if !all_good {
+		report, err := yaml.Marshal(edgeReport)
+		if err != nil {
+			log.Fatalf("Edge report marshaling error: %v", err)
+		}
+
+		log.Fatalf("%s\n", string(report))
 	}
 
-	report, err := yaml.Marshal(edgeReport)
-	if err != nil {
-		log.Fatalf("Edge report marshaling error: %v", err)
-	}
-
-	fmt.Printf("%s\n", string(report))
-	os.Exit(1)
+	fmt.Println("all clear")
 }


### PR DESCRIPTION
#### Synopis

This PR does not address or solve a problem per se. 

---

#### Changes

* use log.Fatal* functions consistently across the board when hitting erros and early exit is required
* use fmt.Sprintf across the board for building strings
* use existing constants for http methods from the http package