### PR TITLE
S3-shield: Terraform and docs updates

### DIFF
--- a/s3-shield/terraform-aws/.pre-commit-config.yaml
+++ b/s3-shield/terraform-aws/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+- repo: https://github.com/antonbabenko/pre-commit-terraform.git
+  rev: v1.97.4
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs
+      args: ['--args=--anchor=false', '--args=--hide resources,modules,data-sources']
+    - id: terraform_tflint
+      args: ['--args=--chdir=__GIT_WORKING_DIR__']

--- a/s3-shield/terraform-aws/README.md
+++ b/s3-shield/terraform-aws/README.md
@@ -1,27 +1,21 @@
-# Deploy on AWS via terraform and cloud-init
-
-[terraform](https://www.terraform.io/) is an automation tool which allows you to manage cloud resources (spin up instances, create security groups, etc.) in cloud environment. The tool is extremely versatile, but we'll focus here on using it to deploy on AWS, using Varnish Enterprise AMIs.
-
-## Requirements
-
-`terraform`, that's it.
-
 ## Getting started
 
-We first need to generate the cloud-init, there you need to edit `../cloud-init/s3.conf`, and then generate the `yaml` file that `terraform` will use:
 
-``` bash
-../cloud-init/generate_yaml.sh
-```
-
-Next, edit `variables.tf` to at least modify the `KEY_NAME` value to match your IAM key pair. You can also tweak the instance type and the region where to spawn it.
-
-To deploy:
+1. Edit the ``../cloud-init/s3.conf`` to match your AWS environment
+2. Generate the yaml configuration, later required by Terraform, as shown below 
 
 ``` shell
-terraform init
-terraform plan
-terraform apply
+$ ../cloud-init/generate_yaml.sh
+```
+
+---
+
+## Provision the infra
+
+``` shell
+$ terraform init
+$ terraform plan -var="key_name=your-key-name"
+$ terraform apply -var="key_name=your-key-name"
 ```
 
 The output should end with something like:
@@ -36,3 +30,36 @@ instance_public_ip_addr = "35.85.51.82"
 ```
 
 In this case, your file will be accessible at http://35.85.51.82/path/to/your/file.png
+
+--- 
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.9.0 |
+| aws | ~> 6.11 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 6.11 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| ami\_owners | Varnish Software marketplace image | `list(string)` | <pre>[<br/>  "679593333241"<br/>]</pre> | no |
+| key\_name | Add your key in Key pairs in AWS | `string` | n/a | yes |
+| region | n/a | `string` | `"us-west-2"` | no |
+| ve6\_instance | n/a | `string` | `"t3.micro"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| instance\_private\_ip\_addr | n/a |
+| instance\_public\_ip\_addr | n/a |
+<!-- END_TF_DOCS -->

--- a/s3-shield/terraform-aws/instance_ve6.tf
+++ b/s3-shield/terraform-aws/instance_ve6.tf
@@ -1,4 +1,4 @@
-data "aws_ami" "ubuntu-ve6" {
+data "aws_ami" "ubuntu_ve6" {
   most_recent = true
 
   filter {
@@ -14,8 +14,8 @@ data "aws_ami" "ubuntu-ve6" {
   owners = var.ami_owners
 }
 
-resource "aws_instance" "tf-ve6" {
-  ami                    = data.aws_ami.ubuntu-ve6.id
+resource "aws_instance" "tf_ve6" {
+  ami                    = data.aws_ami.ubuntu_ve6.id
   instance_type          = var.ve6_instance
   key_name               = var.key_name
   vpc_security_group_ids = [aws_security_group.s3shield_sec_22_80_443.id]

--- a/s3-shield/terraform-aws/instance_ve6.tf
+++ b/s3-shield/terraform-aws/instance_ve6.tf
@@ -11,18 +11,18 @@ data "aws_ami" "ubuntu-ve6" {
     values = ["hvm"]
   }
 
-  owners = ["679593333241"] # Varnish Software marketplace image
+  owners = var.ami_owners
 }
 
 resource "aws_instance" "tf-ve6" {
   ami                    = data.aws_ami.ubuntu-ve6.id
-  instance_type          = "${var.VE6_INSTANCE}"
-  key_name               = "${var.KEY_NAME}"
+  instance_type          = var.ve6_instance
+  key_name               = var.key_name
   vpc_security_group_ids = [aws_security_group.s3shield_sec_22_80_443.id]
   #user_data             = data.template_file.user_data_ve6.rendered
-  user_data              = "${file("../cloud-init/cloud-init-s3-shield.yaml")}"
+  user_data = file("../cloud-init/cloud-init-s3-shield.yaml")
   tags = {
     Project = "varnish-s3-shield"
-    Name = "varnish-s3-shield"
+    Name    = "varnish-s3-shield"
   }
 }

--- a/s3-shield/terraform-aws/output.tf
+++ b/s3-shield/terraform-aws/output.tf
@@ -1,7 +1,7 @@
 output "instance_public_ip_addr" {
-  value = aws_instance.tf-ve6.public_ip
+  value = aws_instance.tf_ve6.public_ip
 }
 
 output "instance_private_ip_addr" {
-  value = aws_instance.tf-ve6.private_ip
+  value = aws_instance.tf_ve6.private_ip
 }

--- a/s3-shield/terraform-aws/provider.tf
+++ b/s3-shield/terraform-aws/provider.tf
@@ -2,12 +2,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.16"
+      version = "~> 6.11"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.9.0"
 }
 
 provider "aws" {
-  region = var.REGION
+  region = var.region
 }

--- a/s3-shield/terraform-aws/variables.tf
+++ b/s3-shield/terraform-aws/variables.tf
@@ -1,16 +1,20 @@
-variable REGION {
-  type = string
+variable "region" {
+  type    = string
   default = "us-west-2"
 }
 
-variable VE6_INSTANCE {
-  type = string
-  default = "t2.micro"
+variable "ve6_instance" {
+  type    = string
+  default = "t3.micro"
 }
 
-# Add your key in Key pairs in AWS and change the name under
-variable KEY_NAME {
-  type = string
-  default = "your_key_pair_name"
+variable "key_name" {
+  type        = string
+  description = "Add your key in Key pairs in AWS"
 }
 
+variable "ami_owners" {
+  type        = list(string)
+  default     = ["679593333241"]
+  description = "Varnish Software marketplace image"
+}


### PR DESCRIPTION
### Synopis

This PR aims to introduce some minimal Terraform best practices, along with a newer TF  and AWS provider version.

---

### Implementation

* prefer lower case variables, upper case ones are usually reserved for environment variables
* prefer underscore instead of dashes in resource or data-lookup names
* run ``terraform fmt`` against all terraform files
* prefer variables instead of hardcoded values in data-lookups
* remove default values for mandatory variables (e.g. ``key_name``)
* extend the README with Terraform requirements/providers/inputs/outputs
* added a pre-commit goodie to format tf files and update the README file accordingly
* moved from ``t2.micro`` to ``t3.micro`` as default instance type

---

### Notes

The tables in the README file have automatically been generated with:

* [pre-commit](https://pre-commit.com/#introduction)
* [terraform-docs](https://github.com/terraform-docs/terraform-docs/#installation)

by running the folllowing in the ``terraform-aws`` folder:

```sh
$ pre-commit run --show-diff-on-failure --all-files terraform_docs
```

----

### Potential trouble

This section is relevant **only** if you already have provisioned infrastructure. Otherwise, if starting from scratch - skip the following lines.

The ``tf-ve6`` resource has been renamed to ``tf_ve6``. 

If you'll ``plan`` this code against already provisioned infra, then Terraform will attempt to create a new ``aws_instance`` resource.

You most likely don't want that - as you already have the instance you need. However, this situation can easily be handled using the Terraform [moved](https://developer.hashicorp.com/terraform/language/moved#complete-configuration) block.

Example:

```hcl
moved {
    from = aws_instance.tf-ve6
    to = aws_instance.tf_ve6
}
```
