### PR TITLE
[DO NOT MERGE] Add heatmap panels for latency and throughput insights

### DIFF
--- a/docker-compose-examples/grafana-monitoring-otel/conf/grafana/provisioning/dashboards/varnish_metrics.json
+++ b/docker-compose-examples/grafana-monitoring-otel/conf/grafana/provisioning/dashboards/varnish_metrics.json
@@ -19,7 +19,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 2,
+  "id": 0,
   "links": [],
   "panels": [
     {
@@ -63,7 +63,7 @@
             "h": 6,
             "w": 2,
             "x": 0,
-            "y": 0
+            "y": 1
           },
           "id": 132,
           "options": {
@@ -130,7 +130,7 @@
             "h": 6,
             "w": 4,
             "x": 2,
-            "y": 0
+            "y": 1
           },
           "id": 129,
           "options": {
@@ -199,7 +199,7 @@
             "h": 6,
             "w": 4,
             "x": 6,
-            "y": 0
+            "y": 1
           },
           "id": 130,
           "options": {
@@ -268,7 +268,7 @@
             "h": 6,
             "w": 4,
             "x": 10,
-            "y": 0
+            "y": 1
           },
           "id": 91,
           "options": {
@@ -403,7 +403,7 @@
             "h": 6,
             "w": 3,
             "x": 14,
-            "y": 0
+            "y": 1
           },
           "id": 100,
           "options": {
@@ -477,7 +477,7 @@
             "h": 6,
             "w": 3,
             "x": 17,
-            "y": 0
+            "y": 1
           },
           "id": 99,
           "options": {
@@ -563,7 +563,7 @@
             "h": 6,
             "w": 4,
             "x": 20,
-            "y": 0
+            "y": 1
           },
           "id": 116,
           "options": {
@@ -690,7 +690,7 @@
             "h": 12,
             "w": 9,
             "x": 0,
-            "y": 19
+            "y": 41
           },
           "id": 127,
           "options": {
@@ -848,7 +848,7 @@
             "h": 12,
             "w": 7,
             "x": 9,
-            "y": 19
+            "y": 41
           },
           "id": 95,
           "options": {
@@ -994,7 +994,7 @@
             "h": 12,
             "w": 8,
             "x": 16,
-            "y": 19
+            "y": 41
           },
           "id": 135,
           "options": {
@@ -1058,7 +1058,7 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1066,462 +1066,463 @@
         "y": 1
       },
       "id": 21,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Requests per second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 8,
+            "x": 0,
+            "y": 2
+          },
+          "id": 30,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_esi_requests[$__rate_interval]))",
+              "instant": false,
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "ESI subrequests",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Operations",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/[bB]ans/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 8,
+            "x": 8,
+            "y": 2
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_purges[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of purge operations executed",
+              "range": true,
+              "refId": "Purges"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_bans[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Active Bans",
+              "range": true,
+              "refId": "Bans"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_ykey_purges[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "YKey purge operations",
+              "range": true,
+              "refId": "Ykey purges"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_ban_req[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Lurker-unfriendly bans",
+              "range": true,
+              "refId": "Lurker-unfriendly bans"
+            }
+          ],
+          "title": "Cache invalidation requests",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Objects invalidated",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 13,
+            "w": 8,
+            "x": 16,
+            "y": 2
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_book_c_ykey_purged[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of objects purged with YKey",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_book_ykey_slicer_purged[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of slicer objects purged with YKey (MSE4)",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_obj_purged[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of purged objects",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_ban_obj_killed[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Objects killed by bans (lookup)",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_ban_lurker_obj_killed[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Objects killed by bans (lurker)",
+              "range": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_ban_lurker_obj_killed_cutoff[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Objects killed by bans for cutoff (lurker)",
+              "range": true,
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_mse3_store_ykey_purged[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of slicer objects purged with YKey (MSE3)",
+              "range": true,
+              "refId": "G"
+            }
+          ],
+          "title": "Objects invalidated",
+          "type": "timeseries"
+        }
+      ],
       "title": "Traffic",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Requests per second",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 13,
-        "w": 8,
-        "x": 0,
-        "y": 2
-      },
-      "id": 30,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_esi_requests[$__rate_interval]))",
-          "instant": false,
-          "legendFormat": "{{host}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "ESI subrequests",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Operations",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "/[bB]ans/"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              },
-              {
-                "id": "unit"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 13,
-        "w": 8,
-        "x": 8,
-        "y": 2
-      },
-      "id": 110,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_purges[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of purge operations executed",
-          "range": true,
-          "refId": "Purges"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_bans[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Active Bans",
-          "range": true,
-          "refId": "Bans"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_ykey_purges[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "YKey purge operations",
-          "range": true,
-          "refId": "Ykey purges"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_ban_req[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Lurker-unfriendly bans",
-          "range": true,
-          "refId": "Lurker-unfriendly bans"
-        }
-      ],
-      "title": "Cache invalidation requests",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Objects invalidated",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 13,
-        "w": 8,
-        "x": 16,
-        "y": 2
-      },
-      "id": 109,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_book_c_ykey_purged[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of objects purged with YKey",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_book_ykey_slicer_purged[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of slicer objects purged with YKey (MSE4)",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_obj_purged[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of purged objects",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_ban_obj_killed[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Objects killed by bans (lookup)",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_ban_lurker_obj_killed[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Objects killed by bans (lurker)",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_ban_lurker_obj_killed_cutoff[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Objects killed by bans for cutoff (lurker)",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_mse3_store_ykey_purged[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of slicer objects purged with YKey (MSE3)",
-          "range": true,
-          "refId": "G"
-        }
-      ],
-      "title": "Objects invalidated",
-      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -1529,12 +1530,12 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 2
       },
       "id": 137,
       "panels": [],
       "repeat": "instance",
-      "title": "Heatmaps",
+      "title": "Latency and Throughput",
       "type": "row"
     },
     {
@@ -1542,7 +1543,7 @@
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "This heatmap shows the TTFB (Avg)",
+      "description": "This heatmap shows the Avg. Time to First Byte (TTFB)",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1562,7 +1563,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 3
       },
       "id": 138,
       "options": {
@@ -1630,7 +1631,7 @@
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "TTFB 95th percentile (p95) from the histogram bucket",
+      "description": "Time to First Byte (TTFB) 95th percentile (p95) from the histogram bucket",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1671,7 +1672,7 @@
         "h": 7,
         "w": 11,
         "x": 12,
-        "y": 16
+        "y": 3
       },
       "id": 139,
       "options": {
@@ -1705,7 +1706,7 @@
           "expr": "histogram_quantile(0.95, sum(rate(varnish_client_duration_ttfb_seconds_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Client",
+          "legendFormat": "Client Side",
           "range": true,
           "refId": "B"
         }
@@ -1718,7 +1719,7 @@
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "This heatmap shows the TTFB (Avg)",
+      "description": "This heatmap shows the Avg. Time to Last Byte (TTFB)",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1738,7 +1739,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 10
       },
       "id": 142,
       "options": {
@@ -1780,7 +1781,7 @@
         {
           "editorMode": "code",
           "expr": "sum(rate(varnish_client_duration_total_seconds_sum[$__rate_interval]))",
-          "legendFormat": " Client TTFB (sec)",
+          "legendFormat": " Client TTLB (sec)",
           "range": true,
           "refId": "A"
         },
@@ -1793,7 +1794,7 @@
           "expr": "sum(rate(varnish_backend_duration_total_seconds_sum[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "legendFormat": " Backend TTFB (secs)",
+          "legendFormat": " Backend TTLB (secs)",
           "range": true,
           "refId": "B"
         }
@@ -1806,7 +1807,7 @@
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "Total Time TTLB 95th percentile (p95) from the histogram bucket",
+      "description": "Total Time of Last Byte (TTFB) percentile (p95)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1847,7 +1848,7 @@
         "h": 7,
         "w": 11,
         "x": 12,
-        "y": 23
+        "y": 10
       },
       "id": 144,
       "options": {
@@ -1881,7 +1882,7 @@
           "expr": "histogram_quantile(0.95, sum(rate(varnish_client_duration_total_seconds_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Client",
+          "legendFormat": "Client Side",
           "range": true,
           "refId": "B"
         }
@@ -1894,7 +1895,7 @@
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "This heatmap show total data transferred per second,",
+      "description": "This heatmap show total data transferred in bits per second",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1914,7 +1915,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 17
       },
       "id": 143,
       "options": {
@@ -2049,7 +2050,7 @@
         "h": 7,
         "w": 11,
         "x": 12,
-        "y": 30
+        "y": 17
       },
       "id": 141,
       "options": {
@@ -2123,7 +2124,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 24
       },
       "id": 88,
       "panels": [
@@ -2199,7 +2200,7 @@
             "h": 10,
             "w": 8,
             "x": 0,
-            "y": 0
+            "y": 108
           },
           "id": 131,
           "options": {
@@ -2315,7 +2316,7 @@
             "h": 5,
             "w": 8,
             "x": 8,
-            "y": 0
+            "y": 108
           },
           "id": 93,
           "options": {
@@ -2422,7 +2423,7 @@
             "h": 5,
             "w": 8,
             "x": 16,
-            "y": 0
+            "y": 108
           },
           "id": 68,
           "options": {
@@ -2529,7 +2530,7 @@
             "h": 5,
             "w": 8,
             "x": 8,
-            "y": 18
+            "y": 113
           },
           "id": 69,
           "options": {
@@ -2662,7 +2663,7 @@
             "h": 5,
             "w": 8,
             "x": 16,
-            "y": 18
+            "y": 113
           },
           "id": 97,
           "options": {
@@ -2782,7 +2783,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 23
+            "y": 118
           },
           "id": 136,
           "options": {
@@ -2897,7 +2898,7 @@
             "h": 5,
             "w": 8,
             "x": 8,
-            "y": 23
+            "y": 118
           },
           "id": 92,
           "options": {
@@ -3306,7 +3307,7 @@
             "h": 5,
             "w": 8,
             "x": 16,
-            "y": 23
+            "y": 118
           },
           "id": 48,
           "options": {
@@ -3451,7 +3452,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 28
+            "y": 123
           },
           "id": 98,
           "options": {
@@ -3696,7 +3697,7 @@
             "h": 5,
             "w": 8,
             "x": 8,
-            "y": 28
+            "y": 123
           },
           "id": 79,
           "options": {
@@ -3831,7 +3832,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 25
       },
       "id": 89,
       "panels": [
@@ -3902,7 +3903,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 1
+            "y": 109
           },
           "id": 102,
           "options": {
@@ -3926,7 +3927,7 @@
                 "uid": "prometheusUID"
               },
               "editorMode": "code",
-              "expr": "sum(varnish_mse4_book_slot_used)/sum(varnish_mse4_book_slot_used + varnish_mse4_book_slot_unused)",
+              "expr": "varnish_mse4",
               "hide": false,
               "instant": false,
               "legendFormat": "Book slots",
@@ -4030,7 +4031,7 @@
             "h": 5,
             "w": 8,
             "x": 8,
-            "y": 1
+            "y": 109
           },
           "id": 108,
           "options": {
@@ -4158,7 +4159,7 @@
             "h": 5,
             "w": 8,
             "x": 16,
-            "y": 1
+            "y": 109
           },
           "id": 106,
           "options": {
@@ -4297,7 +4298,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 19
+            "y": 114
           },
           "id": 133,
           "options": {
@@ -4397,7 +4398,7 @@
             "h": 5,
             "w": 8,
             "x": 8,
-            "y": 19
+            "y": 114
           },
           "id": 111,
           "options": {
@@ -4512,7 +4513,7 @@
             "h": 5,
             "w": 8,
             "x": 16,
-            "y": 19
+            "y": 114
           },
           "id": 112,
           "options": {
@@ -4614,7 +4615,7 @@
             "h": 5,
             "w": 8,
             "x": 0,
-            "y": 24
+            "y": 119
           },
           "id": 104,
           "options": {
@@ -4698,7 +4699,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 26
       },
       "id": 113,
       "panels": [
@@ -4766,7 +4767,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 15
+            "y": 158
           },
           "id": 117,
           "options": {
@@ -4880,7 +4881,7 @@
     ]
   },
   "time": {
-    "from": "now-30h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {
@@ -4898,6 +4899,6 @@
   },
   "timezone": "",
   "title": "Varnish metrics",
-  "uid": "d96e0b09-246c-4a1f-b924-oodvar",
-  "version": 1
+  "uid": "adz7nrj",
+  "version": 3
 }

--- a/docker-compose-examples/grafana-monitoring-otel/conf/grafana/provisioning/dashboards/varnish_metrics.json
+++ b/docker-compose-examples/grafana-monitoring-otel/conf/grafana/provisioning/dashboards/varnish_metrics.json
@@ -1,47 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "prometheusUID",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.2.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -62,11 +19,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 3,
+  "id": 2,
   "links": [],
   "panels": [
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -74,1030 +31,1031 @@
         "y": 0
       },
       "id": 134,
-      "panels": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 2,
+            "x": 0,
+            "y": 0
+          },
+          "id": 132,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "count(varnish_uptime)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Varnish instances",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-orange",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 2,
+            "y": 0
+          },
+          "id": 129,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "(sum(rate(varnish_main_response_hdrbytes[$__rate_interval])) + sum(rate(varnish_main_response_bodybytes[$__rate_interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Bytes",
+              "range": true,
+              "refId": "Bytes"
+            }
+          ],
+          "title": "Serving",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-orange",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 6,
+            "y": 0
+          },
+          "id": 130,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum((rate(varnish_main_client_requests[$__rate_interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Requests/sec",
+              "range": true,
+              "refId": "Requests"
+            }
+          ],
+          "title": "Serving",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-orange",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 10,
+            "y": 0
+          },
+          "id": 91,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "1 - (sum(rate(varnish_backend_response_hdrbytes[$__rate_interval])) + sum(rate(varnish_backend_response_bodybytes[$__rate_interval]))) / (sum(rate(varnish_main_response_hdrbytes[$__rate_interval])) + sum(rate(varnish_main_response_bodybytes[$__rate_interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Bytes",
+              "range": true,
+              "refId": "Bytes"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "1-  sum((rate(varnish_backend_requests[$__rate_interval]))) /sum((rate(varnish_main_client_requests[$__rate_interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Requests",
+              "range": true,
+              "refId": "Requests"
+            }
+          ],
+          "title": "Traffic offload",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 2,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "yellow",
+                    "value": 0
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Healthy backends"
+                },
+                "properties": [
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "green",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Sick backends"
+                },
+                "properties": [
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": 0
+                        },
+                        {
+                          "color": "red",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 14,
+            "y": 0
+          },
+          "id": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(varnish_backend_is_healthy) / count(varnish_backend_is_healthy) ",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Sick",
+              "range": false,
+              "refId": "sick"
+            }
+          ],
+          "title": "Backend Health",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 2,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "yellow",
+                    "value": 0
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 3,
+            "x": 17,
+            "y": 0
+          },
+          "id": 99,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(varnish_mse4_store_online) / count(varnish_mse4_store_online)",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "Stores offline",
+              "range": false,
+              "refId": "stores offline"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "builder",
+              "expr": "",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "MSE4 stores online",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 4,
+            "x": 20,
+            "y": 0
+          },
+          "id": 116,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(varnish_child_panics)",
+              "instant": true,
+              "legendFormat": "MGT uptime",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Panics recorded",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "Data transfer per second, which consists of headers and body bytes in the backend requests and backend responses.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Bits per second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "beresp"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "req"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 9,
+            "x": 0,
+            "y": 19
+          },
+          "id": 127,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_response_hdrbytes[$__rate_interval])+rate(varnish_main_response_bodybytes[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Client response",
+              "range": true,
+              "refId": "resp"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_backend_request_hdrbytes[$__rate_interval])+rate(varnish_backend_request_bodybytes[$__rate_interval]))",
+              "instant": false,
+              "legendFormat": "Backend request",
+              "range": true,
+              "refId": "bereq"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_request_hdrbytes[$__rate_interval])+rate(varnish_main_request_bodybytes[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Client request",
+              "range": true,
+              "refId": "req"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_backend_response_hdrbytes[$__rate_interval])+rate(varnish_backend_response_bodybytes[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Backend response",
+              "range": true,
+              "refId": "beresp"
+            }
+          ],
+          "title": "Data transfer per second",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/^Backend.*/"
+                },
+                "properties": [
+                  {
+                    "id": "custom.transform",
+                    "value": "negative-Y"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 7,
+            "x": 9,
+            "y": 19
+          },
+          "id": 95,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_backend_connections[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Backend connections",
+              "range": true,
+              "refId": "Backend connections"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_sess[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Client connections",
+              "range": true,
+              "refId": "Client connections"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_backend_requests[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Backend requests",
+              "range": true,
+              "refId": "Backend requests"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_client_requests[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Client requests",
+              "range": true,
+              "refId": "Client requests"
+            }
+          ],
+          "title": "New connections and requests",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 12,
+            "w": 8,
+            "x": 16,
+            "y": 19
+          },
+          "id": 135,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "1 - sum(rate(varnish_backend_requests[$__rate_interval])) / sum(rate(varnish_main_client_requests[$__rate_interval]))",
+              "legendFormat": "Requests",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "1 - sum(rate(varnish_main_backend_connections[$__rate_interval])) / sum(rate(varnish_main_sess[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Connections",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "1- (sum(rate(varnish_backend_response_hdrbytes[$__rate_interval])+rate(varnish_backend_response_bodybytes[$__rate_interval]))) / (sum(rate(varnish_main_response_hdrbytes[$__rate_interval])+rate(varnish_main_response_bodybytes[$__rate_interval])))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Bytes",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Offload rate",
+          "type": "timeseries"
+        }
+      ],
       "title": "Overview",
       "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 2,
-        "x": 0,
-        "y": 1
-      },
-      "id": 132,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "count(varnish_uptime)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Varnish instances",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "semi-dark-orange",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 2,
-        "y": 1
-      },
-      "id": 129,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "(sum(rate(varnish_main_response_hdrbytes[$__rate_interval])) + sum(rate(varnish_main_response_bodybytes[$__rate_interval])))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Bytes",
-          "range": true,
-          "refId": "Bytes"
-        }
-      ],
-      "title": "Serving",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "semi-dark-orange",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 6,
-        "y": 1
-      },
-      "id": 130,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum((rate(varnish_main_client_requests[$__rate_interval])))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Requests/sec",
-          "range": true,
-          "refId": "Requests"
-        }
-      ],
-      "title": "Serving",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "semi-dark-orange",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 10,
-        "y": 1
-      },
-      "id": 91,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "1 - (sum(rate(varnish_backend_response_hdrbytes[$__rate_interval])) + sum(rate(varnish_backend_response_bodybytes[$__rate_interval]))) / (sum(rate(varnish_main_response_hdrbytes[$__rate_interval])) + sum(rate(varnish_main_response_bodybytes[$__rate_interval])))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Bytes",
-          "range": true,
-          "refId": "Bytes"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "1-  sum((rate(varnish_backend_requests[$__rate_interval]))) /sum((rate(varnish_main_client_requests[$__rate_interval])))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Requests",
-          "range": true,
-          "refId": "Requests"
-        }
-      ],
-      "title": "Traffic offload",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 2,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "yellow",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Healthy backends"
-            },
-            "properties": [
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "green",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Sick backends"
-            },
-            "properties": [
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 14,
-        "y": 1
-      },
-      "id": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(varnish_backend_is_healthy) / count(varnish_backend_is_healthy) ",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Sick",
-          "range": false,
-          "refId": "sick"
-        }
-      ],
-      "title": "Backend Health",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 2,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "yellow",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 17,
-        "y": 1
-      },
-      "id": 99,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(varnish_mse4_store_online) / count(varnish_mse4_store_online)",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Stores offline",
-          "range": false,
-          "refId": "stores offline"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "builder",
-          "expr": "",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "MSE4 stores online",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 1
-      },
-      "id": 116,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(varnish_child_panics)",
-          "instant": true,
-          "legendFormat": "MGT uptime",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Panics recorded",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "Data transfer per second, which consists of headers and body bytes in the backend requests and backend responses.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Bits per second",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "beresp"
-            },
-            "properties": [
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "req"
-            },
-            "properties": [
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 9,
-        "x": 0,
-        "y": 7
-      },
-      "id": 127,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_response_hdrbytes[$__rate_interval])+rate(varnish_main_response_bodybytes[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Client response",
-          "range": true,
-          "refId": "resp"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_backend_request_hdrbytes[$__rate_interval])+rate(varnish_backend_request_bodybytes[$__rate_interval]))",
-          "instant": false,
-          "legendFormat": "Backend request",
-          "range": true,
-          "refId": "bereq"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_request_hdrbytes[$__rate_interval])+rate(varnish_main_request_bodybytes[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Client request",
-          "range": true,
-          "refId": "req"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_backend_response_hdrbytes[$__rate_interval])+rate(varnish_backend_response_bodybytes[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Backend response",
-          "range": true,
-          "refId": "beresp"
-        }
-      ],
-      "title": "Data transfer per second",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "/^Backend.*/"
-            },
-            "properties": [
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 7,
-        "x": 9,
-        "y": 7
-      },
-      "id": 95,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_backend_connections[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Backend connections",
-          "range": true,
-          "refId": "Backend connections"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_sess[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Client connections",
-          "range": true,
-          "refId": "Client connections"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_backend_requests[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Backend requests",
-          "range": true,
-          "refId": "Backend requests"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_client_requests[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Client requests",
-          "range": true,
-          "refId": "Client requests"
-        }
-      ],
-      "title": "New connections and requests",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 8,
-        "x": 16,
-        "y": 7
-      },
-      "id": 135,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "1 - sum(rate(varnish_backend_requests[$__rate_interval])) / sum(rate(varnish_main_client_requests[$__rate_interval]))",
-          "legendFormat": "Requests",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "1 - sum(rate(varnish_main_backend_connections[$__rate_interval])) / sum(rate(varnish_main_sess[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Connections",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "1- (sum(rate(varnish_backend_response_hdrbytes[$__rate_interval])+rate(varnish_backend_response_bodybytes[$__rate_interval]))) / (sum(rate(varnish_main_response_hdrbytes[$__rate_interval])+rate(varnish_main_response_bodybytes[$__rate_interval])))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Bytes",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Offload rate",
-      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -1105,7 +1063,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 1
       },
       "id": 21,
       "panels": [],
@@ -1179,7 +1137,7 @@
         "h": 13,
         "w": 8,
         "x": 0,
-        "y": 20
+        "y": 2
       },
       "id": 30,
       "options": {
@@ -1200,7 +1158,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.0",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -1301,7 +1259,7 @@
         "h": 13,
         "w": 8,
         "x": 8,
-        "y": 20
+        "y": 2
       },
       "id": 110,
       "options": {
@@ -1322,7 +1280,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.0",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -1447,7 +1405,7 @@
         "h": 13,
         "w": 8,
         "x": 16,
-        "y": 20
+        "y": 2
       },
       "id": 109,
       "options": {
@@ -1468,7 +1426,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.0",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -1571,11 +1529,12 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 15
       },
-      "id": 88,
+      "id": 137,
       "panels": [],
-      "title": "Errors",
+      "repeat": "instance",
+      "title": "Heatmaps",
       "type": "row"
     },
     {
@@ -1583,438 +1542,69 @@
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "",
+      "description": "This heatmap shows the TTFB (Avg)",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
           "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
             },
-            "inspect": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "false": {
-                  "index": 1,
-                  "text": "Sick"
-                },
-                "true": {
-                  "index": 0,
-                  "text": "Healthy"
-                }
-              },
-              "type": "value"
+            "scaleDistribution": {
+              "type": "linear"
             }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
           }
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byType",
-              "options": "boolean"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 8,
+        "h": 7,
+        "w": 12,
         "x": 0,
-        "y": 34
+        "y": 16
       },
-      "id": 131,
+      "id": 138,
       "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
         },
-        "showHeader": true
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (backend_name, host_name) (varnish_backend_is_healthy)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Panel Title",
-      "transformations": [
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "destinationType": "boolean",
-                "targetField": "Value"
-              }
-            ],
-            "fields": {}
-          }
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
         },
-        {
-          "id": "groupingToMatrix",
-          "options": {
-            "columnField": "backend_name",
-            "rowField": "host_name",
-            "valueField": "Value"
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "The number of backends that are marked as sick due to failing health probes or being manually set to sick via varnishadm.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
+        "filterValues": {
+          "le": 1e-9
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 34
-      },
-      "id": 93,
-      "options": {
         "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
         }
       },
-      "pluginVersion": "12.2.0",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
           "editorMode": "code",
-          "expr": "count by (host_name) (varnish_backend_is_healthy) - sum by (host_name)(varnish_backend_is_healthy)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{host_name}}",
-          "range": true,
-          "refId": "sick"
-        }
-      ],
-      "title": "Sick backends",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Failures per second",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 34
-      },
-      "id": 68,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum by (failure_type) (rate(varnish_main_session_failed{failure_type!=\"\"}[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{failure_type}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Session failures",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Errors per second",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 39
-      },
-      "id": 69,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (failure_type) (rate(varnish_backend_failed{failure_type!=\"\"}[$__rate_interval]))",
-          "instant": false,
-          "legendFormat": "Fetch failed ({{failure_type}})",
+          "expr": "(sum(rate(varnish_client_duration_ttfb_seconds_sum[$__rate_interval]))/sum(rate(varnish_client_duration_ttfb_seconds_count[$__rate_interval])))",
+          "legendFormat": " Client TTFB (sec)",
           "range": true,
           "refId": "A"
         },
@@ -2024,1699 +1614,40 @@
             "uid": "prometheusUID"
           },
           "editorMode": "code",
-          "expr": "sum(rate(varnish_main_backend_wait_failed[$__rate_interval]))",
+          "expr": "(sum(rate(varnish_backend_duration_ttfb_seconds_sum[$__rate_interval]))/sum(rate(varnish_backend_duration_ttfb_seconds_count[$__rate_interval])))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Backend conn. waited in queue and did not get a connection",
-          "range": true,
-          "refId": "N"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_bgfetch_no_thread[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Background fetch failed (no thread)",
-          "range": true,
-          "refId": "O"
-        }
-      ],
-      "title": "Backend errors",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 39
-      },
-      "id": 97,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_main_stale_fetch_delivers[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Stale deliveries",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_main_stale_fetch_rearms[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Stale object rearmed",
+          "legendFormat": " Backend TTFB (secs)",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Stale",
-      "type": "timeseries"
+      "title": "TTFB (Avg)",
+      "type": "heatmap"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "",
+      "description": "TTFB 95th percentile (p95) from the histogram bucket",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 80,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
             "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
             "stacking": {
               "group": "A",
               "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 0,
-        "y": 44
-      },
-      "id": 136,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "count by (host_name) (varnish_mse4_book_online) - sum by (host_name) (varnish_mse4_book_online)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Books offline ({{host_name}})",
-          "range": true,
-          "refId": "books"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "count by (host_name) (varnish_mse4_store_online) - sum by (host_name) (varnish_mse4_store_online)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Stores offline ({{host_name}})",
-          "range": true,
-          "refId": "stores"
-        }
-      ],
-      "title": "MSE4 offline books/stores",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 44
-      },
-      "id": 92,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_client_req_417[$__rate_interval]))",
-          "instant": false,
-          "legendFormat": "Client requests received, subject to 417 errors",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_vdp_error[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Session Err VDP_FAILURE",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_stream_failure[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Session Err VDP_ERROR_FETCH",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_rapid_reset[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Session Err RAPID_RESET",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_esi_errors[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "ESI parse errors",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_ws_backend_overflow[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "workspace_backend overflows",
-          "range": true,
-          "refId": "H"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_ws_client_overflow[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "workspace_client overflows",
-          "range": true,
-          "refId": "I"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_thread_thread_overflow[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "workspace_thread overflows",
-          "range": true,
-          "refId": "J"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_ws_session_overflow[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "workspace_session overflows",
-          "range": true,
-          "refId": "K"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_vcl_fail[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "VCL failures",
-          "range": true,
-          "refId": "L"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_lru_limited[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Reached nuke_limit",
-          "range": true,
-          "refId": "M"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_varnish_main_losthdr[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "HTTP header overflows",
-          "range": true,
-          "refId": "N"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_vcl_failure[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Session Err VCL_FAILURE",
-          "range": true,
-          "refId": "O"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_thread_limited[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Threads hit max",
-          "range": true,
-          "refId": "P"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_thread_failed[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Thread creation failed",
-          "range": true,
-          "refId": "Q"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_task_track_failed[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Failed to track a task",
-          "range": true,
-          "refId": "R"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_session_dropped[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Sessions dropped for thread",
-          "range": true,
-          "refId": "S"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_request_dropped[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Requests dropped",
-          "range": true,
-          "refId": "T"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_goto_dns_lookup_fails[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of unresolved DNS lookups from vmod_goto's DNS",
-          "range": true,
-          "refId": "U"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_main_vgs_msg_nospace[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Gravestone message insufficient space",
-          "range": true,
-          "refId": "V"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(varnish_child_panics[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Child process panics",
-          "range": true,
-          "refId": "Z"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_client_req_400[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Client requests received, subject to 400 errors",
-          "range": true,
-          "refId": "Client requests received, subject to 400 errors"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_main_client_resp_500[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Delivery failed due to insufficient workspace.",
-          "range": true,
-          "refId": "Delivery failed due to insufficient workspace."
-        }
-      ],
-      "title": "Various errors",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Errors per second",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 44
-      },
-      "id": 48,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_main_esi_errors[$__rate_interval])",
-          "instant": false,
-          "legendFormat": "ESI parse errors (unlock)",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_main_esi_warnings[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "ESI parse warnings (unlock)",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_main_esi_maxdepth[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "ESI hit max_esi_depth",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_main_esi_req_abort[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Aborted ESI subrequests",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "ESI parse errors",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 0,
-        "y": 49
-      },
-      "id": 98,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_c_eviction_failure[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Object or chunk eviction failures",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_c_allocation_failure[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Allocator failures",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_book_g_unreachable_objects)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Objects from unreachable stores in the books",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_book_c_slot_liberation_failure[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Slot liberation failures",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_allocation_failure[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Allocation request failures",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_allocation_failure_timeout[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Allocation request failure due to a timeout",
-          "range": true,
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_allocation_failure_noslot[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "llocation request failure due to no slot available",
-          "range": true,
-          "refId": "G"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_segment_remap_fail[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Segment remap failure to produce towards the reserve",
-          "range": true,
-          "refId": "H"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_segment_prune_fail[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Segment pruning failure to produce towards the reserve",
-          "range": true,
-          "refId": "I"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_io_limited[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "IO engine has been request limited",
-          "range": true,
-          "refId": "J"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_g_io_blocked_read[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Read IO operations currently blocked",
-          "range": true,
-          "refId": "K"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_g_io_blocked_write[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Write IO operations currently blocked",
-          "range": true,
-          "refId": "L"
-        }
-      ],
-      "title": "MSE4 errors",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 49
-      },
-      "id": 79,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "rate(varnish_brotli_c_br_fail[$__rate_interval])",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "Brotli compressions failures",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "rate(varnish_brotli_test_decompression_fail[$__rate_interval])",
-          "format": "time_series",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "Brotli test decompression failures",
-          "range": true,
-          "refId": "B",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "rate(varnish_brotli_decompression_fail[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Brotli decompression Failures",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(varnish_main_brotli_c_br_fail[$__rate_interval])",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "D",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "disableTextWrap": false,
-          "editorMode": "code",
-          "expr": "rate(varnish_main_brotli_c_testunbr_fail[$__rate_interval])",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "E",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "rate(varnish_varnish_main_brotli_c_unbr_fail[$__rate_interval])",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "F",
-          "useBackend": false
-        }
-      ],
-      "title": "Brotli errors",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 54
-      },
-      "id": 89,
-      "panels": [],
-      "title": "Saturation",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Percentage per book",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 0,
-        "y": 55
-      },
-      "id": 102,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_book_slot_used)/sum(varnish_mse4_book_slot_used + varnish_mse4_book_slot_unused)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Book slots",
-          "range": true,
-          "refId": "Book slots"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_byte_used)/sum(varnish_mse4_byte_used + varnish_mse4_byte_unused)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Memory",
-          "range": true,
-          "refId": "Memory"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_store_bytes_used)/sum(varnish_mse4_store_bytes_used + varnish_mse4_store_bytes_unused)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Disk",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "MSE4 usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 55
-      },
-      "id": 108,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_object_used)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "All objects",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "varnish_mse4_object_ephemeral",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Ephemeral objects",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_object_persisted)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Persisted objects with at least one chunk in memory",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Objects in the cache",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 55
-      },
-      "id": 106,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_main_mem_private) / count(varnish_main_mem_private)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Worker process private memory usage",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_main_mem_rss) / count(varnish_main_mem_rss)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Worker process RSS memory usage",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_main_mem_file) / count (varnish_main_mem_file)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "RSS file usage",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_main_mem_swap) / count(varnish_main_mem_swap)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Varnish worker process swap usage",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "Memory governor",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
             }
           },
           "mappings": [],
@@ -3737,12 +1668,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 0,
-        "y": 60
+        "h": 7,
+        "w": 11,
+        "x": 12,
+        "y": 16
       },
-      "id": 133,
+      "id": 139,
       "options": {
         "legend": {
           "calcs": [],
@@ -3756,118 +1687,12 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.0",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
           "editorMode": "code",
-          "expr": "sum by (host_name) (varnish_main_thread_live)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Threads",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 8,
-        "y": 60
-      },
-      "id": 111,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_g_ykey_keys)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "In total",
+          "expr": "histogram_quantile(0.95, sum(rate(varnish_backend_duration_ttfb_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "Backend Side",
           "range": true,
           "refId": "A"
         },
@@ -3877,214 +1702,85 @@
             "uid": "prometheusUID"
           },
           "editorMode": "code",
-          "expr": "sum(varnish_mse4_book_ykey_keys)",
+          "expr": "histogram_quantile(0.95, sum(rate(varnish_client_duration_ttfb_seconds_bucket[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
-          "legendFormat": "in book {{mse4_book}}",
+          "legendFormat": "Client",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Number of ykeys in the cache",
-      "type": "timeseries"
+      "title": "TTFB (95th percentile)",
+      "type": "histogram"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheusUID"
       },
-      "description": "",
+      "description": "This heatmap shows the TTFB (Avg)",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
             }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
+          }
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 16,
-        "y": 60
-      },
-      "id": 112,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "expr": "sum(varnish_mse4_book_varyspecs)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of Vary header instruction keys",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Number of Vary header keys",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
+        "h": 7,
+        "w": 12,
         "x": 0,
-        "y": 65
+        "y": 23
       },
-      "id": 104,
+      "id": 142,
       "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
         },
         "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
         }
       },
-      "pluginVersion": "12.2.0",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
           "editorMode": "code",
-          "expr": "sum(rate(varnish_main_lru_nuked[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of LRU nuked objects",
+          "expr": "sum(rate(varnish_client_duration_total_seconds_sum[$__rate_interval]))",
+          "legendFormat": " Client TTFB (sec)",
           "range": true,
           "refId": "A"
         },
@@ -4094,10 +1790,186 @@
             "uid": "prometheusUID"
           },
           "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_book_c_objects_liberated[$__rate_interval]))",
+          "expr": "sum(rate(varnish_backend_duration_total_seconds_sum[$__rate_interval]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "Number of objects evicted to gain free book slots",
+          "legendFormat": " Backend TTFB (secs)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Total Time (TTLB)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusUID"
+      },
+      "description": "Total Time TTLB 95th percentile (p95) from the histogram bucket",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 12,
+        "y": 23
+      },
+      "id": 144,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(varnish_backend_duration_total_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "Backend Side",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(varnish_client_duration_total_seconds_bucket[$__rate_interval])) by (le))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Client",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Total Time (TTLB 95th percentile)",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusUID"
+      },
+      "description": "This heatmap show total data transferred per second,",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 143,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "8 * sum(rate(varnish_client_request_bytes_byte_sum[$__rate_interval])) / 1e6",
+          "legendFormat": "  Request bits/sec (from client → Varnish)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "editorMode": "code",
+          "expr": "8 * sum(rate(varnish_client_response_bytes_byte_sum[$__rate_interval])) / 1e6",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "  Response bits/sec (from Varnish → client)",
           "range": true,
           "refId": "B"
         },
@@ -4107,10 +1979,10 @@
             "uid": "prometheusUID"
           },
           "editorMode": "code",
-          "expr": "sum(rate(varnish_mse4_store_c_segment_pruned_objects[$__rate_interval]))",
+          "expr": "8 * sum(rate(varnish_backend_request_bytes_byte_sum[$__rate_interval])) / 1e6",
           "hide": false,
           "instant": false,
-          "legendFormat": "Number of objects evicted during segment pruning",
+          "legendFormat": "   Request bits/sec (from Varnish → backend)",
           "range": true,
           "refId": "C"
         },
@@ -4120,176 +1992,2867 @@
             "uid": "prometheusUID"
           },
           "editorMode": "code",
-          "expr": "sum(rate(varnish_main_expired[$__rate_interval]))",
+          "expr": "8 * sum(rate(varnish_backend_response_bytes_byte_sum[$__rate_interval])) / 1e6",
           "hide": false,
           "instant": false,
-          "legendFormat": "Expired objects",
+          "legendFormat": "   Response bits/sec (from backend → Varnish)",
           "range": true,
           "refId": "D"
         }
       ],
-      "title": "Objects evicted or expired",
-      "type": "timeseries"
+      "title": "Total Transfer Size (Bits/sec)",
+      "type": "heatmap"
     },
     {
-      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheusUID"
+      },
+      "description": "TTLB 95th percentile (p95) from the histogram bucket",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 11,
+        "x": 12,
+        "y": 30
+      },
+      "id": 141,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "8 * histogram_quantile(0.95, sum(rate(varnish_client_request_bytes_byte_bucket[$__rate_interval])) by (le)) / 1e6",
+          "legendFormat": "Client Request Bytes (p95)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "editorMode": "code",
+          "expr": "8 * histogram_quantile(0.95, sum(rate(varnish_client_response_bytes_byte_bucket[$__rate_interval])) by (le)) / 1e6",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Client Response Bytes (p95)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "editorMode": "code",
+          "expr": "8 * histogram_quantile(0.95, sum(rate(varnish_backend_request_bytes_byte_bucket[$__rate_interval])) by (le)) / 1e6",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Backend Request Bytes (p95)",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "editorMode": "code",
+          "expr": "8 * histogram_quantile(0.95, sum(rate(varnish_backend_response_bytes_byte_bucket[$__rate_interval])) by (le)) / 1e6",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Backend Response Bytes (p95)",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Transfer size bits/sec (95th percentile)",
+      "type": "histogram"
+    },
+    {
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 37
       },
-      "id": 113,
-      "panels": [],
-      "title": "Latency",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheusUID"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
+      "id": 88,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Lookup latency",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "false": {
+                      "index": 1,
+                      "text": "Sick"
+                    },
+                    "true": {
+                      "index": 0,
+                      "text": "Healthy"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
             },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
+            "overrides": [
               {
-                "color": "green",
-                "value": 0
+                "matcher": {
+                  "id": "byType",
+                  "options": "boolean"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "basic",
+                      "type": "color-background"
+                    }
+                  }
+                ]
               }
             ]
           },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 12,
-        "x": 0,
-        "y": 71
-      },
-      "id": 117,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "last"
+          "gridPos": {
+            "h": 10,
+            "w": 8,
+            "x": 0,
+            "y": 0
+          },
+          "id": 131,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by (backend_name, host_name) (varnish_backend_is_healthy)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "A"
+            }
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.2.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "rate(varnish_mse4_book_c_ykey_iter_10ms[$__rate_interval])",
-          "instant": false,
-          "legendFormat": "Number of ykey iterations taking 0.01s or less",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheusUID"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "rate(varnish_mse4_book_c_ykey_iter_100ms[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of ykey iterations taking between 0.01s and 0.1s",
-          "range": true,
-          "refId": "B"
+          "title": "Panel Title",
+          "transformations": [
+            {
+              "id": "convertFieldType",
+              "options": {
+                "conversions": [
+                  {
+                    "destinationType": "boolean",
+                    "targetField": "Value"
+                  }
+                ],
+                "fields": {}
+              }
+            },
+            {
+              "id": "groupingToMatrix",
+              "options": {
+                "columnField": "backend_name",
+                "rowField": "host_name",
+                "valueField": "Value"
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "rate(varnish_mse4_book_c_ykey_iter_1000ms[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of ykey iterations taking between 0.1s and 1s",
-          "range": true,
-          "refId": "C"
+          "description": "The number of backends that are marked as sick due to failing health probes or being manually set to sick via varnishadm.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 0
+          },
+          "id": 93,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "count by (host_name) (varnish_backend_is_healthy) - sum by (host_name)(varnish_backend_is_healthy)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{host_name}}",
+              "range": true,
+              "refId": "sick"
+            }
+          ],
+          "title": "Sick backends",
+          "type": "timeseries"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "editorMode": "code",
-          "expr": "rate(varnish_mse4_book_c_ykey_iter_1000ms_up[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Number of ykey iterations taking more than 1s",
-          "range": true,
-          "refId": "D"
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Failures per second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 0
+          },
+          "id": 68,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum by (failure_type) (rate(varnish_main_session_failed{failure_type!=\"\"}[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "{{failure_type}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Session failures",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Errors per second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 18
+          },
+          "id": 69,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by (failure_type) (rate(varnish_backend_failed{failure_type!=\"\"}[$__rate_interval]))",
+              "instant": false,
+              "legendFormat": "Fetch failed ({{failure_type}})",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_backend_wait_failed[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Backend conn. waited in queue and did not get a connection",
+              "range": true,
+              "refId": "N"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_bgfetch_no_thread[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Background fetch failed (no thread)",
+              "range": true,
+              "refId": "O"
+            }
+          ],
+          "title": "Backend errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 18
+          },
+          "id": 97,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_main_stale_fetch_delivers[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Stale deliveries",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_main_stale_fetch_rearms[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Stale object rearmed",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Stale",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 23
+          },
+          "id": 136,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "count by (host_name) (varnish_mse4_book_online) - sum by (host_name) (varnish_mse4_book_online)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Books offline ({{host_name}})",
+              "range": true,
+              "refId": "books"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "count by (host_name) (varnish_mse4_store_online) - sum by (host_name) (varnish_mse4_store_online)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Stores offline ({{host_name}})",
+              "range": true,
+              "refId": "stores"
+            }
+          ],
+          "title": "MSE4 offline books/stores",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 23
+          },
+          "id": 92,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_client_req_417[$__rate_interval]))",
+              "instant": false,
+              "legendFormat": "Client requests received, subject to 417 errors",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_vdp_error[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Session Err VDP_FAILURE",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_stream_failure[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Session Err VDP_ERROR_FETCH",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_rapid_reset[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Session Err RAPID_RESET",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_esi_errors[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "ESI parse errors",
+              "range": true,
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_ws_backend_overflow[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "workspace_backend overflows",
+              "range": true,
+              "refId": "H"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_ws_client_overflow[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "workspace_client overflows",
+              "range": true,
+              "refId": "I"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_thread_thread_overflow[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "workspace_thread overflows",
+              "range": true,
+              "refId": "J"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_ws_session_overflow[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "workspace_session overflows",
+              "range": true,
+              "refId": "K"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_vcl_fail[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "VCL failures",
+              "range": true,
+              "refId": "L"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_lru_limited[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Reached nuke_limit",
+              "range": true,
+              "refId": "M"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_varnish_main_losthdr[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "HTTP header overflows",
+              "range": true,
+              "refId": "N"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_vcl_failure[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Session Err VCL_FAILURE",
+              "range": true,
+              "refId": "O"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_thread_limited[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Threads hit max",
+              "range": true,
+              "refId": "P"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_thread_failed[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Thread creation failed",
+              "range": true,
+              "refId": "Q"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_task_track_failed[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Failed to track a task",
+              "range": true,
+              "refId": "R"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_session_dropped[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Sessions dropped for thread",
+              "range": true,
+              "refId": "S"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_request_dropped[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Requests dropped",
+              "range": true,
+              "refId": "T"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_goto_dns_lookup_fails[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of unresolved DNS lookups from vmod_goto's DNS",
+              "range": true,
+              "refId": "U"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_main_vgs_msg_nospace[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Gravestone message insufficient space",
+              "range": true,
+              "refId": "V"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(varnish_child_panics[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Child process panics",
+              "range": true,
+              "refId": "Z"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_client_req_400[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Client requests received, subject to 400 errors",
+              "range": true,
+              "refId": "Client requests received, subject to 400 errors"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_client_resp_500[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Delivery failed due to insufficient workspace.",
+              "range": true,
+              "refId": "Delivery failed due to insufficient workspace."
+            }
+          ],
+          "title": "Various errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Errors per second",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 23
+          },
+          "id": 48,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_main_esi_errors[$__rate_interval])",
+              "instant": false,
+              "legendFormat": "ESI parse errors (unlock)",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_main_esi_warnings[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "ESI parse warnings (unlock)",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_main_esi_maxdepth[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "ESI hit max_esi_depth",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_main_esi_req_abort[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Aborted ESI subrequests",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "ESI parse errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 28
+          },
+          "id": 98,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_c_eviction_failure[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Object or chunk eviction failures",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_c_allocation_failure[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Allocator failures",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_book_g_unreachable_objects)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Objects from unreachable stores in the books",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_book_c_slot_liberation_failure[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Slot liberation failures",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_allocation_failure[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Allocation request failures",
+              "range": true,
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_allocation_failure_timeout[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Allocation request failure due to a timeout",
+              "range": true,
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_allocation_failure_noslot[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "llocation request failure due to no slot available",
+              "range": true,
+              "refId": "G"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_segment_remap_fail[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Segment remap failure to produce towards the reserve",
+              "range": true,
+              "refId": "H"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_segment_prune_fail[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Segment pruning failure to produce towards the reserve",
+              "range": true,
+              "refId": "I"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_io_limited[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "IO engine has been request limited",
+              "range": true,
+              "refId": "J"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_g_io_blocked_read[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Read IO operations currently blocked",
+              "range": true,
+              "refId": "K"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_g_io_blocked_write[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Write IO operations currently blocked",
+              "range": true,
+              "refId": "L"
+            }
+          ],
+          "title": "MSE4 errors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 28
+          },
+          "id": 79,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(varnish_brotli_c_br_fail[$__rate_interval])",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "Brotli compressions failures",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(varnish_brotli_test_decompression_fail[$__rate_interval])",
+              "format": "time_series",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "Brotli test decompression failures",
+              "range": true,
+              "refId": "B",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_brotli_decompression_fail[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Brotli decompression Failures",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(varnish_main_brotli_c_br_fail[$__rate_interval])",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "D",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "expr": "rate(varnish_main_brotli_c_testunbr_fail[$__rate_interval])",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "E",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "rate(varnish_varnish_main_brotli_c_unbr_fail[$__rate_interval])",
+              "fullMetaSearch": false,
+              "hide": false,
+              "includeNullMetadata": true,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "F",
+              "useBackend": false
+            }
+          ],
+          "title": "Brotli errors",
+          "type": "timeseries"
         }
       ],
-      "title": "Ykey iteration latency",
-      "type": "timeseries"
+      "title": "Errors",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 89,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Percentage per book",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "id": 102,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_book_slot_used)/sum(varnish_mse4_book_slot_used + varnish_mse4_book_slot_unused)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Book slots",
+              "range": true,
+              "refId": "Book slots"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_byte_used)/sum(varnish_mse4_byte_used + varnish_mse4_byte_unused)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Memory",
+              "range": true,
+              "refId": "Memory"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_store_bytes_used)/sum(varnish_mse4_store_bytes_used + varnish_mse4_store_bytes_unused)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Disk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "MSE4 usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_object_used)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "All objects",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "varnish_mse4_object_ephemeral",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Ephemeral objects",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_object_persisted)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Persisted objects with at least one chunk in memory",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Objects in the cache",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_main_mem_private) / count(varnish_main_mem_private)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Worker process private memory usage",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_main_mem_rss) / count(varnish_main_mem_rss)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Worker process RSS memory usage",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_main_mem_file) / count (varnish_main_mem_file)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "RSS file usage",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_main_mem_swap) / count(varnish_main_mem_swap)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Varnish worker process swap usage",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Memory governor",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 19
+          },
+          "id": 133,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum by (host_name) (varnish_main_thread_live)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Threads",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 8,
+            "y": 19
+          },
+          "id": 111,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_g_ykey_keys)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "In total",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_book_ykey_keys)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "in book {{mse4_book}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Number of ykeys in the cache",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 16,
+            "y": 19
+          },
+          "id": 112,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(varnish_mse4_book_varyspecs)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of Vary header instruction keys",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Number of Vary header keys",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 8,
+            "x": 0,
+            "y": 24
+          },
+          "id": 104,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_lru_nuked[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of LRU nuked objects",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_book_c_objects_liberated[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of objects evicted to gain free book slots",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_mse4_store_c_segment_pruned_objects[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of objects evicted during segment pruning",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(varnish_main_expired[$__rate_interval]))",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Expired objects",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Objects evicted or expired",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Saturation",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 113,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheusUID"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "green",
+                "mode": "fixed"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Lookup latency",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "id": 117,
+          "options": {
+            "legend": {
+              "calcs": [
+                "min",
+                "max",
+                "mean",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.2.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "rate(varnish_mse4_book_c_ykey_iter_10ms[$__rate_interval])",
+              "instant": false,
+              "legendFormat": "Number of ykey iterations taking 0.01s or less",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "rate(varnish_mse4_book_c_ykey_iter_100ms[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of ykey iterations taking between 0.01s and 0.1s",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "rate(varnish_mse4_book_c_ykey_iter_1000ms[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of ykey iterations taking between 0.1s and 1s",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheusUID"
+              },
+              "editorMode": "code",
+              "expr": "rate(varnish_mse4_book_c_ykey_iter_1000ms_up[$__rate_interval])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "Number of ykey iterations taking more than 1s",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Ykey iteration latency",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Latency",
+      "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [],
@@ -4320,9 +4883,21 @@
     "from": "now-30h",
     "to": "now"
   },
-  "timepicker": {},
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
   "timezone": "",
   "title": "Varnish metrics",
   "uid": "d96e0b09-246c-4a1f-b924-oodvar",
-  "version": 3
+  "version": 1
 }


### PR DESCRIPTION
@gquintard lets tweak the heatmaps here. As discussed, we need otel 2.0 with ttfb/ttlb support out before merge...

**Dashboards contain insights on:**
- TTFB (Avg / p95): visualize client ↔ backend first-byte latency
- TTLB (Avg / p95): show total end-to-end response times
- Transfer Size (Bits/sec / p95): display traffic throughput and 95th-percentile payload sizes