### PR TITLE
mkfs service requires platform setting

### DIFF
--- a/docker-compose-examples/grafana-monitoring-otel/compose.yaml
+++ b/docker-compose-examples/grafana-monitoring-otel/compose.yaml
@@ -8,6 +8,7 @@ services:
       - varnish
 
   mkfs:
+    #platform: linux/amd64 # Uncomment this line when running on Apple M1
     user: root
     volumes:
       - ./mse4.conf:/etc/varnish/mse4.conf

--- a/docker-compose-examples/grafana-monitoring-otel/compose.yaml
+++ b/docker-compose-examples/grafana-monitoring-otel/compose.yaml
@@ -8,7 +8,7 @@ services:
       - varnish
 
   mkfs:
-    #platform: linux/amd64 # Uncomment this line when running on Apple M1
+    platform: linux/amd64
     user: root
     volumes:
       - ./mse4.conf:/etc/varnish/mse4.conf
@@ -25,7 +25,7 @@ services:
 
   varnish:
     hostname: varnish
-    #platform: linux/amd64 # Uncomment this line when running on Apple M1
+    platform: linux/amd64
     volumes:
       - ./mse4.conf:/etc/varnish/mse4.conf
       - ./data/mse/disk:/var/lib/mse/disk
@@ -68,7 +68,7 @@ services:
   exporter:
     command: varnish-otel
     entrypoint: []
-    #platform: linux/amd64 # Uncomment this line when running on Apple M1
+    platform: linux/amd64
     user: root
     volumes:
       - workdir:/var/lib/varnish


### PR DESCRIPTION
The "mkfs" service also requires the "platform" setting for Apple M1 users.

I ran it on my Apple M1 and since it also downloads `varnish-plus`, it also reported that the package could not be found. By adding `platform: linux/amd64` to `mkfs`, it problem was fixed.

@gquintard can't we just uncomment the platform setting and enable it for everyone? 