### PR TITLE
Grafana monitoring fixes thijs

### DIFF
--- a/docker-compose-examples/grafana-monitoring/conf/grafana/provisioning/dashboards/varnish_metrics.json
+++ b/docker-compose-examples/grafana-monitoring/conf/grafana/provisioning/dashboards/varnish_metrics.json
@@ -18,18 +18,12 @@
   "description": "A dashboard to use to debug a running varnish instance. Easily track requests, cache hits, network i/o, sessions, threads, bans, ban lurker and the ban list size",
   "editable": true,
   "fiscalYearStartMonth": 0,
-  "gnetId": 9903,
   "graphTooltip": 0,
   "id": 2,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "loki",
-        "uid": "lokiUID"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -39,15 +33,6 @@
       "id": 25,
       "panels": [],
       "repeat": "cluster",
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "lokiUID"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Row title",
       "type": "row"
     },
@@ -78,7 +63,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -86,7 +71,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -103,6 +88,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -114,19 +100,21 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "15s",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 15
         }
@@ -162,7 +150,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -170,7 +158,7 @@
               }
             ]
           },
-          "unit": "none"
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -187,6 +175,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -198,19 +187,21 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "irate(varnish_main_backend_req{instance=~\"^$varnish_instance.*\"}[5m])",
+          "editorMode": "code",
+          "expr": "irate(varnish_main_backend_req{instance=~\"^$varnish_instance.*\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "15s",
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "varnish_main_backend_req",
+          "range": true,
           "refId": "A",
           "step": 15
         }
@@ -245,7 +236,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -270,6 +261,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -281,7 +273,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -327,7 +319,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -352,6 +344,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -363,7 +356,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -416,7 +409,7 @@
             "steps": [
               {
                 "color": "rgba(245, 54, 54, 0.9)",
-                "value": null
+                "value": 0
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
@@ -438,7 +431,6 @@
         "x": 14,
         "y": 1
       },
-      "hideTimeOverride": false,
       "id": 6,
       "maxDataPoints": 100,
       "options": {
@@ -456,7 +448,7 @@
         "showThresholdMarkers": false,
         "sizing": "auto"
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -464,8 +456,8 @@
             "uid": "prometheusUID"
           },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "avg(rate(varnish_main_cache_hit[5m])) / rate(varnish_main_client_req[5m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_cache_hit[$__rate_interval]) / rate(varnish_main_client_req[$__rate_interval])",
           "format": "time_series",
           "fullMetaSearch": false,
           "hide": false,
@@ -486,10 +478,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "loki",
-        "uid": "lokiUID"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -498,15 +486,6 @@
       },
       "id": 26,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "lokiUID"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Row title",
       "type": "row"
     },
@@ -527,6 +506,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 40,
             "gradientMode": "none",
@@ -543,6 +523,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -559,7 +540,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -642,23 +623,26 @@
           "width": 400
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "frontend",
           "metric": "",
+          "range": true,
           "refId": "A",
           "step": 30
         },
@@ -667,11 +651,13 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_backend_req{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_backend_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "backend",
+          "range": true,
           "refId": "B",
           "step": 30
         },
@@ -692,10 +678,12 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_fetch_total{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_fetch_total{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "fetched objects",
+          "range": true,
           "refId": "D",
           "step": 60
         }
@@ -721,6 +709,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 60,
             "gradientMode": "none",
@@ -737,6 +726,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -754,7 +744,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -831,23 +821,26 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "avg(rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "avg(rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[$__rate_interval]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "cache hit %",
+          "range": true,
           "refId": "A",
           "step": 60
         },
@@ -856,12 +849,14 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "avg(1 - (rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[5m]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m])))",
+          "editorMode": "code",
+          "expr": "avg(1 - (rate(varnish_main_cache_hit{instance=~\"^($varnish_instance).*\"}[$__rate_interval]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "cache miss %",
+          "range": true,
           "refId": "B",
           "step": 60
         },
@@ -870,12 +865,14 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "avg(1 - (rate(varnish_main_cache_hitpass{instance=~\"^($varnish_instance).*\"}[5m]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[5m])))",
+          "editorMode": "code",
+          "expr": "avg(1 - (rate(varnish_main_cache_hitpass{instance=~\"^($varnish_instance).*\"}[$__rate_interval]) / rate(varnish_main_client_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval])))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "cache hit pass %",
+          "range": true,
           "refId": "C",
           "step": 60
         }
@@ -886,10 +883,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "loki",
-        "uid": "lokiUID"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -898,15 +891,6 @@
       },
       "id": 27,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "lokiUID"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Row title",
       "type": "row"
     },
@@ -927,6 +911,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "none",
@@ -943,6 +928,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -959,7 +945,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1078,7 +1064,6 @@
         "x": 0,
         "y": 23
       },
-      "hideTimeOverride": false,
       "id": 12,
       "options": {
         "legend": {
@@ -1093,23 +1078,26 @@
           "width": 400
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_s_resp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_main_s_resp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_s_resp_hdrbytes{instance=~\"^($varnish_instance).*\"}[$__rate_interval]) + irate(varnish_main_s_resp_bodybytes{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "frontend",
+          "range": true,
           "refId": "A",
           "step": 30
         },
@@ -1118,13 +1106,15 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[$__rate_interval]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "backend",
           "metric": "",
+          "range": true,
           "refId": "B",
           "step": 30
         },
@@ -1133,10 +1123,12 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[5m]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[5m])) by (backend)",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_backend_beresp_hdrbytes{instance=~\"^($varnish_instance).*\"}[$__rate_interval]) + irate(varnish_backend_beresp_bodybytes{instance=~\"^($varnish_instance).*\"}[$__rate_interval])) by (backend)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "backend {{ backend }}",
+          "range": true,
           "refId": "C",
           "step": 60
         }
@@ -1162,6 +1154,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 40,
             "gradientMode": "none",
@@ -1178,6 +1171,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -1194,7 +1188,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1281,7 +1275,6 @@
         "x": 12,
         "y": 23
       },
-      "hideTimeOverride": false,
       "id": 13,
       "options": {
         "legend": {
@@ -1296,23 +1289,26 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_n_expired{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_n_expired{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "expired",
           "metric": "varnish_main_n_object",
+          "range": true,
           "refId": "A",
           "step": 60
         },
@@ -1321,11 +1317,13 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_n_lru_moved{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_n_lru_moved{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "LRU moved",
+          "range": true,
           "refId": "C",
           "step": 60
         },
@@ -1334,11 +1332,13 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "sum(irate(varnish_main_n_lru_nuked{instance=~\"^($varnish_instance).*\"}[5m]))",
+          "editorMode": "code",
+          "expr": "sum(irate(varnish_main_n_lru_nuked{instance=~\"^($varnish_instance).*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "LRU nuked",
+          "range": true,
           "refId": "B",
           "step": 60
         },
@@ -1362,10 +1362,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "loki",
-        "uid": "lokiUID"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1374,15 +1370,6 @@
       },
       "id": 28,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "lokiUID"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "New row",
       "type": "row"
     },
@@ -1403,6 +1390,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1419,6 +1407,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -1435,7 +1424,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1466,20 +1455,23 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_conn{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_conn{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. success",
+          "range": true,
           "refId": "A",
           "step": 60
         },
@@ -1488,9 +1480,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_recycle{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_recycle{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. recycles",
+          "range": true,
           "refId": "B",
           "step": 60
         },
@@ -1499,9 +1493,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_reuse{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_reuse{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. reuses",
+          "range": true,
           "refId": "C",
           "step": 60
         },
@@ -1510,9 +1506,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_fail{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_fail{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. failures",
+          "range": true,
           "refId": "D",
           "step": 60
         },
@@ -1521,9 +1519,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_unhealthy{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_unhealthy{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. not attempted",
+          "range": true,
           "refId": "E",
           "step": 60
         },
@@ -1532,9 +1532,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_busy{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_busy{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. too many",
+          "range": true,
           "refId": "F",
           "step": 60
         },
@@ -1543,9 +1545,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_req{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_req{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend requests made",
+          "range": true,
           "refId": "G",
           "step": 60
         },
@@ -1554,9 +1558,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_main_backend_retry{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_main_backend_retry{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Backend conn. retry",
+          "range": true,
           "refId": "H",
           "step": 60
         },
@@ -1565,9 +1571,11 @@
             "type": "prometheus",
             "uid": "prometheusUID"
           },
-          "expr": "rate(varnish_backend_conn{instance=~\"^($varnish_instance).*\"}[1m])",
+          "editorMode": "code",
+          "expr": "rate(varnish_backend_conn{instance=~\"^($varnish_instance).*\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "Concurrent connections to backend",
+          "range": true,
           "refId": "I",
           "step": 60
         }
@@ -1593,6 +1601,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1609,6 +1618,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -1624,7 +1634,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1655,11 +1665,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -1694,6 +1705,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1710,6 +1722,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -1725,7 +1738,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1755,11 +1768,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -1846,10 +1860,6 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "loki",
-        "uid": "lokiUID"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1858,15 +1868,6 @@
       },
       "id": 29,
       "panels": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "lokiUID"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "New row",
       "type": "row"
     },
@@ -1887,6 +1888,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1903,6 +1905,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -1918,7 +1921,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1949,11 +1952,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -2045,6 +2049,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2061,6 +2066,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -2076,7 +2082,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2107,11 +2113,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -2157,6 +2164,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -2173,6 +2181,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -2188,7 +2197,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2219,11 +2228,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.3",
+      "pluginVersion": "12.2.1",
       "targets": [
         {
           "datasource": {
@@ -2275,14 +2285,14 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -2291,30 +2301,23 @@
           "uid": "prometheusUID"
         },
         "definition": "",
-        "hide": 0,
         "includeAll": true,
         "label": "Instance",
-        "multi": false,
         "name": "varnish_instance",
         "options": [],
         "query": "label_values(varnish_up, instance)",
         "refresh": 1,
         "regex": "/^(.*):/",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "2024-08-13T15:34:27.201Z",
-    "to": "2024-08-13T16:54:27.233Z"
+    "from": "now-5m",
+    "to": "now"
   },
   "timepicker": {
-    "now": true,
     "nowDelay": "",
     "refresh_intervals": [
       "5s",
@@ -2327,22 +2330,10 @@
       "1h",
       "2h",
       "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
     ]
   },
   "timezone": "browser",
   "title": "Varnish metrics",
   "uid": "ecbe1e96-9e52-40b6-b7ce-742538729dd8",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/docker-compose-examples/grafana-monitoring/docker-compose.yaml
+++ b/docker-compose-examples/grafana-monitoring/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
 
   varnish:
     image: varnish
+    platform: linux/amd64
     command: -n varnish
     volumes:
       - workdir:/var/lib/varnish
@@ -34,6 +35,7 @@ services:
 
   exporter:
     image: stat-exporter
+    platform: linux/amd64
     command: /tmp/prometheus_varnish_exporter -n varnish -verbose
     volumes:
       - workdir:/var/lib/varnish
@@ -59,6 +61,7 @@ services:
 
   promtail:
     image: ncsa-promtail
+    platform: linux/amd64
     entrypoint: ""
     command: bash -c "varnishncsa -t off -n varnish | /tmp/promtail -config.file=/etc/promtail/config.yml --stdin"
     volumes:


### PR DESCRIPTION
Added `platform: linux/amd64` to ensure the Varnish-related containers work on Mac.

Made some changes to the metrics dashboard in Grafana:

- Fixed hit rate counter by removing the `avg()` function
- Added units to the rate counters (`req/s`)
- Replaced hardcoded intervals with `$__rate_interval`
- Replaced the hardcoded time interval with a relative one
- All other changes were made by Grafana