### PR TITLE
Add deviceatlas3-tester harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+varnish-enterprise.lic

--- a/deviceatlas3-tester/.gitignore
+++ b/deviceatlas3-tester/.gitignore
@@ -1,0 +1,2 @@
+/deviceatlas3-tester
+devices.json

--- a/deviceatlas3-tester/Dockerfile
+++ b/deviceatlas3-tester/Dockerfile
@@ -1,0 +1,23 @@
+FROM varnish/varnish-enterprise
+
+USER root
+
+# varnish-go's log/adm/stat packages are cgo bindings against libvarnishapi,
+# hence building on top of varnish-enterprise itself (with -dev headers)
+# rather than a generic golang image.
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		varnish-plus-deviceatlas3 varnish-plus-dev pkg-config curl ca-certificates \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl -fsSL https://go.dev/dl/go1.27.0.linux-amd64.tar.gz | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /src
+COPY . .
+RUN go mod download && go build -o /usr/local/bin/deviceatlas3-tester .
+
+COPY default.vcl /etc/varnish/default.vcl
+
+USER varnish
+
+ENTRYPOINT ["/usr/local/bin/deviceatlas3-tester"]

--- a/deviceatlas3-tester/README.md
+++ b/deviceatlas3-tester/README.md
@@ -1,0 +1,90 @@
+# deviceatlas3-tester
+
+Test harness for `vmod-deviceatlas3` (https://docs.varnish-software.com/varnish-enterprise/vmods/deviceatlas3/).
+Starts a real `varnishd` with the vmod loaded, feeds it requests defined in a
+YAML test suite, and checks the resulting `deviceatlas-results` header
+against the expected value declared for each case.
+
+## Test suite format
+
+A YAML file containing a flat list of test cases:
+
+```yaml
+- name: iphone-safari
+  request:
+    headers:
+      User-Agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X)..."
+  full_lookup: false
+  expected:
+    isMobilePhone: "1"
+    vendor: "Apple"
+
+- name: client-hints-full-lookup
+  request:
+    headers:
+      Sec-CH-UA-Mobile: "?1"
+      Sec-CH-UA-Platform: "\"Android\""
+  full_lookup: true
+  expected:
+    isMobilePhone: "1"
+```
+
+- `request.headers`: headers to send on the test request (e.g. `User-Agent`,
+  `Sec-CH-UA*`).
+- `expected`: map of property name -> the exact string that property lookup
+  must return. One request is sent per entry.
+- `full_lookup`: `false` calls `deviceatlas3.lookup()` (User-Agent only),
+  `true` calls `deviceatlas3.lookup_all()` (all request headers, including
+  Client Hints).
+
+See `testdata/example-suite.yaml` for a fuller example.
+
+## Building and running
+
+```bash
+docker build -t deviceatlas3-tester .
+
+./run.sh testsuite.yaml devices.json varnish-license.lic [parallelism]
+```
+
+You can also run the docker container manually:
+
+```bash
+docker run --rm \
+  -v /tmp/testsuite.yaml:/tmp/testsuite.yaml:ro \
+  -v /tmp/devices.json:/tmp/devices.json:ro \
+  -v /tmp/varnish-license.lic:/etc/varnish/varnish-enterprise.lic:ro \
+  deviceatlas3-tester \
+  -db /tmp/devices.json -tests /tmp/testsuite.yaml -parallelism 8
+```
+
+Flags:
+
+- `-db` (required): path to the DeviceAtlas database file, as visible inside
+  the container.
+- `-tests` (required): path to the YAML test suite file, as visible inside
+  the container.
+- `-parallelism` (default `128`): number of test cases to run concurrently.
+
+There's no license flag: mount your license file read-only at
+`/etc/varnish/varnish-enterprise.lic`, `varnishd`'s default license path.
+
+Exit code is non-zero if any test case fails.
+
+## How it works
+
+- `default.vcl` is a static VCL file baked into the image at
+  `/etc/varnish/default.vcl`. It reads the DeviceAtlas database path from the
+  `DEVICEATLAS_DB_PATH` environment variable via `std.getenv()` in
+  `vcl_init`. The tester sets that variable (from `-db`) on the `varnishd`
+  child process it starts via
+  [varnish-go](https://pkg.go.dev/github.com/varnish/varnish-go)'s `vtest`
+  package.
+- `vcl_recv` always returns `synth(200)`. `vcl_synth` calls
+  `deviceatlas3.lookup()` or `deviceatlas3.lookup_all()` depending on the
+  `deviceatlas-full-lookup` request header, and sets the result on the
+  `deviceatlas-results` response header.
+- Each entry in a case's `expected` map is a separate property lookup, so it
+  becomes its own request: same `request.headers` and `full_lookup`, with
+  `deviceatlas-property` set to that map key. The response's
+  `deviceatlas-results` is compared against the map value.

--- a/deviceatlas3-tester/default.vcl
+++ b/deviceatlas3-tester/default.vcl
@@ -1,0 +1,25 @@
+vcl 4.1;
+
+import deviceatlas3;
+import std;
+
+backend default none;
+
+sub vcl_init {
+	if (deviceatlas3.loadfile(std.getenv("DEVICEATLAS_DB_PATH")) != 0) {
+		return (fail);
+	}
+}
+
+sub vcl_recv {
+	return (synth(200));
+}
+
+sub vcl_synth {
+	if (req.http.deviceatlas-full-lookup == "true") {
+		set resp.http.deviceatlas-results = deviceatlas3.lookup_all(req.http.deviceatlas-property);
+	} else {
+		set resp.http.deviceatlas-results = deviceatlas3.lookup(req.http.User-Agent, req.http.deviceatlas-property);
+	}
+	return (deliver);
+}

--- a/deviceatlas3-tester/go.mod
+++ b/deviceatlas3-tester/go.mod
@@ -1,0 +1,8 @@
+module github.com/varnish/toolbox/deviceatlas3-tester
+
+go 1.25.1
+
+require (
+	github.com/varnish/varnish-go v0.2.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/deviceatlas3-tester/go.sum
+++ b/deviceatlas3-tester/go.sum
@@ -1,0 +1,6 @@
+github.com/varnish/varnish-go v0.2.0 h1:SeNPg9mwRRcNr75NwKZCLLoLfdOmfUSxohL6W4hb41Q=
+github.com/varnish/varnish-go v0.2.0/go.mod h1:pOtL08gnbm9cnDPjIcmBXcBOF8Xgl8rD651Upk3bwyI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/deviceatlas3-tester/main.go
+++ b/deviceatlas3-tester/main.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/varnish/varnish-go/vtest"
+	"gopkg.in/yaml.v3"
+)
+
+const vclPath = "/etc/varnish/default.vcl"
+
+type RequestSpec struct {
+	Headers map[string]string `yaml:"headers"`
+}
+
+type TestCase struct {
+	Name       string            `yaml:"name"`
+	Request    RequestSpec       `yaml:"request"`
+	Expected   map[string]string `yaml:"expected"`
+	FullLookup bool              `yaml:"full_lookup"`
+}
+
+// check is one property lookup within a TestCase: TestCase.Expected fans out
+// into one check (and one request) per property.
+type check struct {
+	caseName   string
+	request    RequestSpec
+	property   string
+	expected   string
+	fullLookup bool
+}
+
+type result struct {
+	check
+	actual string
+	err    error
+}
+
+func main() {
+	dbPath := flag.String("db", "", "path to the DeviceAtlas database file")
+	testsPath := flag.String("tests", "", "path to the YAML test suite file")
+	parallelism := flag.Int("parallelism", 128, "number of tests to run concurrently")
+	flag.Parse()
+
+	if *dbPath == "" || *testsPath == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	cases, err := loadTestCases(*testsPath)
+	if err != nil {
+		log.Fatalf("loading test cases: %v", err)
+	}
+	checks := expand(cases)
+
+	v, err := vtest.New().
+		VclFile(vclPath).
+		SetEnv("DEVICEATLAS_DB_PATH", *dbPath).
+		// deviceatlas3 requires a stack of at least 256KB, see
+		// https://docs.varnish-software.com/varnish-enterprise/vmods/deviceatlas3/
+		Parameter("thread_pool_stack", "256k").
+		Start()
+	if err != nil {
+		log.Fatalf("starting varnish: %v", err)
+	}
+	defer v.Stop()
+
+	results := runChecks(v.URL, checks, *parallelism)
+	failed := report(results)
+
+	if hasRequestError(results) {
+		fmt.Fprintln(os.Stderr, "\n--- varnishd output ---")
+		for _, line := range v.SysLogs() {
+			fmt.Fprintln(os.Stderr, line)
+		}
+	}
+
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func hasRequestError(results []result) bool {
+	for _, r := range results {
+		if r.err != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func loadTestCases(path string) ([]TestCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cases []TestCase
+	if err := yaml.Unmarshal(data, &cases); err != nil {
+		return nil, err
+	}
+	return cases, nil
+}
+
+// expand fans each TestCase out into one check per entry in its Expected map,
+// since each property lookup needs its own request (deviceatlas-property is
+// a single header value).
+func expand(cases []TestCase) []check {
+	var checks []check
+	for _, tc := range cases {
+		for property, expected := range tc.Expected {
+			checks = append(checks, check{
+				caseName:   tc.Name,
+				request:    tc.Request,
+				property:   property,
+				expected:   expected,
+				fullLookup: tc.FullLookup,
+			})
+		}
+	}
+	return checks
+}
+
+func runChecks(baseURL string, checks []check, parallelism int) []result {
+	in := make(chan check)
+	out := make(chan result)
+
+	var wg sync.WaitGroup
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for c := range in {
+				out <- runCheck(baseURL, c)
+			}
+		}()
+	}
+
+	go func() {
+		for _, c := range checks {
+			in <- c
+		}
+		close(in)
+	}()
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	results := make([]result, 0, len(checks))
+	for r := range out {
+		results = append(results, r)
+	}
+	return results
+}
+
+func runCheck(baseURL string, c check) result {
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/", nil)
+	if err != nil {
+		return result{check: c, err: err}
+	}
+	for k, v := range c.request.Headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("deviceatlas-property", c.property)
+	req.Header.Set("deviceatlas-full-lookup", fmt.Sprintf("%t", c.fullLookup))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return result{check: c, err: err}
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	return result{check: c, actual: resp.Header.Get("deviceatlas-results")}
+}
+
+func report(results []result) int {
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].caseName != results[j].caseName {
+			return results[i].caseName < results[j].caseName
+		}
+		return results[i].property < results[j].property
+	})
+
+	failed := 0
+	for _, r := range results {
+		label := fmt.Sprintf("%s[%s]", r.caseName, r.property)
+		switch {
+		case r.err != nil:
+			failed++
+			fmt.Printf("FAIL %s: request error: %v\n", label, r.err)
+		case r.actual != r.expected:
+			failed++
+			fmt.Printf("FAIL %s: expected %q, got %q\n", label, r.expected, r.actual)
+		default:
+			fmt.Printf("PASS %s\n", label)
+		}
+	}
+	fmt.Printf("\n%d/%d passed\n", len(results)-failed, len(results))
+	return failed
+}

--- a/deviceatlas3-tester/run.sh
+++ b/deviceatlas3-tester/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <testsuite.yaml> <database.json> <varnish-license.lic> [parallelism]" >&2
+	exit 2
+fi
+
+for f in "$1" "$2" "$3"; do
+	if [ ! -f "$f" ]; then
+		echo "error: file not found: $f" >&2
+		exit 2
+	fi
+done
+
+testsuite=$(realpath "$1")
+database=$(realpath "$2")
+license=$(realpath "$3")
+parallelism=${4:-128}
+
+docker run --rm \
+	-v "$testsuite:/tmp/testsuite.yaml:ro" \
+	-v "$database:/tmp/devices.json:ro" \
+	-v "$license:/etc/varnish/varnish-enterprise.lic:ro" \
+	deviceatlas3-tester \
+	-db /tmp/devices.json -tests /tmp/testsuite.yaml -parallelism "$parallelism"

--- a/deviceatlas3-tester/testdata/example-suite.yaml
+++ b/deviceatlas3-tester/testdata/example-suite.yaml
@@ -1,0 +1,31 @@
+# Example DeviceAtlas3 test suite. Property names and expected values below
+# are illustrative only - replace with values that match your database.
+#
+# Each entry in `expected` triggers its own request/lookup (one property per
+# request), all sharing the same `request` headers and `full_lookup` mode.
+
+- name: iphone-safari
+  request:
+    headers:
+      User-Agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1"
+  full_lookup: false
+  expected:
+    isMobilePhone: "1"
+    vendor: "Apple"
+
+- name: desktop-chrome
+  request:
+    headers:
+      User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+  full_lookup: false
+  expected:
+    isMobilePhone: "0"
+
+- name: client-hints-full-lookup
+  request:
+    headers:
+      Sec-CH-UA-Mobile: "?1"
+      Sec-CH-UA-Platform: "\"Android\""
+  full_lookup: true
+  expected:
+    isMobilePhone: "1"


### PR DESCRIPTION
## Summary
- New self-contained test harness for `vmod-deviceatlas3`: YAML-declared test cases (request headers, expected property values, single vs. full lookup) run against a real `varnishd` started via `varnish-go`'s `vtest` package.
- Single-stage `Dockerfile` (built on `varnish/varnish-enterprise`, since `varnish-go`'s cgo bindings need to link against the same `libvarnishapi`) installs `varnish-plus-deviceatlas3` and builds the Go tester.
- `run.sh <testsuite.yaml> <database.json> <varnish-license.lic> [parallelism]` wraps the `docker run` invocation for engineers.
- Verified against a real DeviceAtlas database + license (not committed): correctly passes/fails property lookups, including catching a real `thread_pool_stack` stack-overflow bug in `deviceatlas3.lookup()` that the vmod docs call out explicitly.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `gofmt -l .` clean
- [x] `docker build -t deviceatlas3-tester deviceatlas3-tester/` succeeds
- [x] `./run.sh` against a real DeviceAtlas db/license: passes expected cases, fails a deliberately-wrong one, correct exit codes
- [x] `run.sh` rejects missing/typo'd file args before invoking `docker run`